### PR TITLE
Run component tests on schedule and demand

### DIFF
--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -13,7 +13,8 @@ on:
       run-component-tests:
         description: 'Run component tests'
         required: true
-        default: 'false'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,7 +24,7 @@ jobs:
   component-tests:
     name: Deploy Kind Orchestrator and Run Component Tests
     if: |
-      github.event.label.name == 'run-component-tests'
+      ${{ inputs.run-component-tests || github.event_name == 'schedule' || github.event.label.name == 'run-component-tests' }}
     runs-on: ubuntu-24.04-16core-64GB # ubuntu-24.04-4core-16GB ubuntu-22.04-32core-128GB & ubuntu-24.04-16core-64GB
     timeout-minutes: 60
     env:
@@ -49,7 +50,6 @@ jobs:
 
       - name: Setup asdf and install dependencies
         uses: open-edge-platform/orch-utils/.github/actions/setup-asdf@main
-
 
       - name: Checkout app-orch-catalog repository
         uses: actions/checkout@v4
@@ -81,6 +81,7 @@ jobs:
           echo "Orchestrator deployment done!"
           echo "Root App Status:"
           kubectl -n dev get applications root-app -o yaml
+
       - name: Verify Kind Deployment
         timeout-minutes: 50
         run: |
@@ -96,8 +97,6 @@ jobs:
           echo "Orchestrator deployment verified!"
           mage router:stop router:start || true
           echo "Router restarted"
-    
-
 
       - name: Setup Test environment
         shell: bash
@@ -139,7 +138,6 @@ jobs:
               sleep 10
             fi
           done  
-
 
       - name: Run Catalog Component Tests
         working-directory: app-orch-catalog/test


### PR DESCRIPTION
## Description

Run when github event is schedule or if user runs on demand or if label name is `run-component-tests`. Also, set input type as bool.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
