### PR TITLE
Bump OPA version to v0.70.0

### DIFF
--- a/internal/northbound/application_test.go
+++ b/internal/northbound/application_test.go
@@ -1519,7 +1519,6 @@ func (s *NorthBoundDBErrTestSuite) TestApplicationUpdateInvalidArgs() {
 	}
 }
 
-// change to trigger CI
 func (s *NorthBoundDBErrTestSuite) TestApplicationWatchInvalidArgs() {
 	tests := map[string]struct {
 		req *catalogv3.WatchApplicationsRequest


### PR DESCRIPTION
## Description

Fixes linting problems

## Changes

- bump OPA rules scanner to v0.70.0
- don't run hadolint on the vendor directory

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [x] Tests passed
- [x] Documentation updated
