### PR TITLE
Set proxy environment variables using build arguments

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,11 @@ FROM golang:1.24.2 AS base
 
 ENV CGO_ENABLED=0
 
+# Set proxy environment variables using build arguments
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV ATLAS_VERSION=v0.32.1-9f69a85-canary


### PR DESCRIPTION
## Description

When using the make buildall target from the emf repo behind proxy, the curl command does not have access to the proxy settings even if the docker client is configured to work behind proxy. This change modifies the Dockerfile so that curl can run behind proxy.


## Changes

build/Dockerfile

## Additional Information

Locally 

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
