### PR TITLE
WIP: tool to convert deployment packages into "helm install" commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ build: mod-update ## Runs build stage
 	go build -o build/_output/rest-proxy ./cmd/rest-proxy
 	go build -o build/_output/catalog-schema ./cmd/schema
 	go build -o build/_output/helm-to-dp ./cmd/helm-to-dp
+	go build -o build/_output/dp-to-helm ./cmd/dp-to-helm
 
 .PHONY: install
 install: ## Installs the application-catalog server and the schema generation/validation tool

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
+	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
+	"github.com/spf13/cobra"
+	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
+)
+
+var (
+	rootCmd     = &cobra.Command{
+		Use:   "dp-to-helm <dir>",
+		Short: "Convert a Deployment Package to a Helm install command",
+		Long:  "This tool takes a deployment package and outputs the equivalent helm install command",
+	}
+)
+
+func FindApp(r *yamlreader.YamlReader, name, version string) (*catalogv3.Application, error) {
+	for _, app := range r.Applications {
+		if app.Name == name && app.Version == version {
+			return app, nil
+		}
+	}
+	return nil, fmt.Errorf("application %s with version %s not found", name, version)
+}
+
+func FindRegistry(r *yamlreader.YamlReader, name string) (*catalogv3.Registry, error) {
+	for _, reg := range r.Registries {
+		if reg.Name == name {
+			return reg, nil
+		}
+	}
+	return nil, fmt.Errorf("registry %s not found", name)
+}
+
+func FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
+	for _, profile := range dp.Profiles {
+		if profile.Name == name {
+			return profile, nil
+		}
+	}
+	return nil, fmt.Errorf("deployment profile %s not found", name)
+}
+
+func FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
+	for _, appProfile := range app.Profiles {
+		if appProfile.Name == name {
+			return appProfile, nil
+		}
+	}
+	return nil, fmt.Errorf("application profile %s not found", name)
+}
+
+func PrintDPHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage) error {
+    profileName := dp.DefaultProfileName
+	profile, err := FindDeploymentProfile(dp, profileName)
+	if err != nil {
+		return err
+	}
+    fmt.Printf("# using deployment package profile: %s\n", profileName)
+	cmds := make([]string,0)
+   for _, app := range dp.ApplicationReferences {
+       app, err := FindApp(r, app.Name, app.Version)
+	   if err != nil {
+		   return err
+	   }
+	   reg, err := FindRegistry(r, app.HelmRegistryName)
+	   if err != nil {
+		   return err
+	   }
+	   var namespace string
+	   namespace, okay := dp.DefaultNamespaces[app.Name]
+	   if !okay {
+		   namespace = "default"
+	   }
+	   appProfileName := profile.ApplicationProfiles[app.Name]
+	   appProfile, err := FindAppProfile(app, appProfileName)
+	   if err != nil {
+		   return err
+	   }
+	   _ = appProfile
+	   valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
+	   fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
+	   url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)
+	   helmCmd := fmt.Sprintf("helm install %s %s --version %s --namespace %s -f %s", dp.Name, url, app.ChartVersion, namespace, valuesFileName)
+	   cmds = append(cmds, helmCmd)
+   }
+   for _, cmd := range cmds {
+	   fmt.Println(cmd)
+   }
+   return nil
+}
+
+func mainCommand(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		err := cmd.Usage()
+		verboseerror.FatalErrCheck(err, "Failed to print usage: %v", err)
+		return
+	}
+
+	dir := args[0]
+
+	r := &yamlreader.YamlReader{}
+	fileSet, err := r.ReadYamlFilesFromDir(dir)
+	if err != nil {
+		verboseerror.FatalErrCheck(err, "Failed to read YAML files from directory: %v", err)
+		return
+	}
+	fileSets, err := r.ExpandFileSet(fileSet)
+	if err != nil {
+		verboseerror.FatalErrCheck(err, "Failed to expand file set: %v", err)
+		return
+	}
+	for _, fileSet := range fileSets {
+		err := r.ProcessFiles(fileSet)
+		if err != nil {
+			verboseerror.FatalErrCheck(err, "Failed to load YAML specs: %v", err)
+			return
+		}
+	}
+	for _, dp := range r.DeploymentPackages {
+		err := PrintDPHelmCommands(r, dp)
+		if err != nil {
+			verboseerror.FatalErrCheck(err, "Failed to print helm commands: %v", err)
+			return
+		}
+	}
+}
+
+func main() {
+	rootCmd.PersistentFlags().BoolVarP(&verboseerror.Quiet, "quiet", "q", false, "enable quiet mode, suppressing info level messages")
+	rootCmd.Run = mainCommand
+
+	err := rootCmd.Execute()
+	verboseerror.FatalErrCheck(err, "Failed to execute root command: %v", err)
+}

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -6,14 +6,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
-	"github.com/spf13/cobra"
+	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
+	"github.com/spf13/cobra"
 )
 
 var (
-	rootCmd     = &cobra.Command{
+	rootCmd = &cobra.Command{
 		Use:   "dp-to-helm <dir>",
 		Short: "Convert a Deployment Package to a Helm install command",
 		Long:  "This tool takes a deployment package and outputs the equivalent helm install command",
@@ -57,43 +57,43 @@ func FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile
 }
 
 func PrintDPHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage) error {
-    profileName := dp.DefaultProfileName
+	profileName := dp.DefaultProfileName
 	profile, err := FindDeploymentProfile(dp, profileName)
 	if err != nil {
 		return err
 	}
-    fmt.Printf("# using deployment package profile: %s\n", profileName)
-	cmds := make([]string,0)
-   for _, app := range dp.ApplicationReferences {
-       app, err := FindApp(r, app.Name, app.Version)
-	   if err != nil {
-		   return err
-	   }
-	   reg, err := FindRegistry(r, app.HelmRegistryName)
-	   if err != nil {
-		   return err
-	   }
-	   var namespace string
-	   namespace, okay := dp.DefaultNamespaces[app.Name]
-	   if !okay {
-		   namespace = "default"
-	   }
-	   appProfileName := profile.ApplicationProfiles[app.Name]
-	   appProfile, err := FindAppProfile(app, appProfileName)
-	   if err != nil {
-		   return err
-	   }
-	   _ = appProfile
-	   valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
-	   fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
-	   url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)
-	   helmCmd := fmt.Sprintf("helm install %s %s --version %s --namespace %s -f %s", dp.Name, url, app.ChartVersion, namespace, valuesFileName)
-	   cmds = append(cmds, helmCmd)
-   }
-   for _, cmd := range cmds {
-	   fmt.Println(cmd)
-   }
-   return nil
+	fmt.Printf("# using deployment package profile: %s\n", profileName)
+	cmds := make([]string, 0)
+	for _, app := range dp.ApplicationReferences {
+		app, err := FindApp(r, app.Name, app.Version)
+		if err != nil {
+			return err
+		}
+		reg, err := FindRegistry(r, app.HelmRegistryName)
+		if err != nil {
+			return err
+		}
+		var namespace string
+		namespace, okay := dp.DefaultNamespaces[app.Name]
+		if !okay {
+			namespace = "default"
+		}
+		appProfileName := profile.ApplicationProfiles[app.Name]
+		appProfile, err := FindAppProfile(app, appProfileName)
+		if err != nil {
+			return err
+		}
+		_ = appProfile
+		valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
+		fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
+		url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)
+		helmCmd := fmt.Sprintf("helm install %s %s --version %s --namespace %s -f %s", dp.Name, url, app.ChartVersion, namespace, valuesFileName)
+		cmds = append(cmds, helmCmd)
+	}
+	for _, cmd := range cmds {
+		fmt.Println(cmd)
+	}
+	return nil
 }
 
 func mainCommand(cmd *cobra.Command, args []string) {

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -164,6 +164,9 @@ func GetHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage, 
 		for _, param := range namedParams {
 			helmCmd += fmt.Sprintf(" --set %s=\"%s\"", param.name, param.value)
 		}
+		if namespace != "default" {
+			cmds = append(cmds, fmt.Sprintf("kubectl create namespace %s || true", namespace))
+		}
 		cmds = append(cmds, helmCmd)
 	}
 

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -12,11 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type Param struct {
-	name  string
-	value string
-}
-
 var (
 	profile      string
 	listProfiles bool
@@ -40,7 +35,8 @@ func mainCommand(cmd *cobra.Command, args []string) {
 
 	r := &dptohelm.DpToHelm{}
 
-	r.SetOverrides(rawOverrides)
+	err := r.SetOverrides(rawOverrides)
+	verboseerror.FatalErrCheck(err)
 
 	fileSet, err := r.ReadYamlFilesFromDir(dir)
 	verboseerror.FatalErrCheck(err)

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -4,6 +4,9 @@
 
 package main
 
+// dp-to-helm is a tool that takes a deployment package as input and emits the set of "helm install"
+// commands that would be used to install the deployment package without using the orchestrator.
+
 import (
 	"fmt"
 

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -191,6 +191,7 @@ func mainCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		err := cmd.Usage()
 		verboseerror.FatalErrCheck(err)
+		return
 	}
 
 	dir := args[0]

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -5,35 +5,56 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
 	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/spf13/cobra"
-	"os"
-	"bufio"
-	"strings"
 )
 
 type Param struct {
-	name string
+	name  string
 	value string
 }
 
 var (
-	profile       string
-	listProfiles  bool
-	allParams	 bool
-	rawOverrides 	 []string
-	Overrides map[string]string
-	rootCmd = &cobra.Command{
+	profile      string
+	listProfiles bool
+	allParams    bool
+	rawOverrides []string
+	rootCmd      = &cobra.Command{
 		Use:   "dp-to-helm <dir>",
 		Short: "Convert a Deployment Package to a Helm install command",
 		Long:  "This tool takes a deployment package and outputs the equivalent helm install command",
 	}
 )
 
-func FindApp(r *yamlreader.YamlReader, name, version string) (*catalogv3.Application, error) {
+type DpToHelm struct {
+	yamlreader.YamlReader
+	overrides map[string]string
+}
+
+func (r *DpToHelm) SetOverrides(rawOverrides []string) {
+	r.overrides = make(map[string]string)
+	for _, override := range rawOverrides {
+		parts := strings.Split(override, "=")
+		if len(parts) != 2 {
+			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+		}
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if name == "" || value == "" {
+			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+		}
+		r.overrides[name] = value
+	}
+}
+
+func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
 	for _, app := range r.Applications {
 		if app.Name == name && app.Version == version {
 			return app, nil
@@ -42,7 +63,7 @@ func FindApp(r *yamlreader.YamlReader, name, version string) (*catalogv3.Applica
 	return nil, fmt.Errorf("application %s with version %s not found", name, version)
 }
 
-func FindRegistry(r *yamlreader.YamlReader, name string) (*catalogv3.Registry, error) {
+func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
 	for _, reg := range r.Registries {
 		if reg.Name == name {
 			return reg, nil
@@ -51,7 +72,7 @@ func FindRegistry(r *yamlreader.YamlReader, name string) (*catalogv3.Registry, e
 	return nil, fmt.Errorf("registry %s not found", name)
 }
 
-func FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
+func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
 	for _, profile := range dp.Profiles {
 		if profile.Name == name {
 			return profile, nil
@@ -60,7 +81,7 @@ func FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catal
 	return nil, fmt.Errorf("deployment profile %s not found", name)
 }
 
-func FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
+func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
 	for _, appProfile := range app.Profiles {
 		if appProfile.Name == name {
 			return appProfile, nil
@@ -69,11 +90,11 @@ func FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile
 	return nil, fmt.Errorf("application profile %s not found", name)
 }
 
-func ApplyParameters(appProfile *catalogv3.Profile) ([]Param, error) {
+func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
 	namedParams := make([]Param, 0)
 	for _, param := range appProfile.ParameterTemplates {
 		// if param was overridden on the command line, use that value
-		override, ok := Overrides[param.Name]
+		override, ok := r.overrides[param.Name]
 		if ok {
 			namedParam := Param{
 				name:  param.Name,
@@ -96,7 +117,7 @@ func ApplyParameters(appProfile *catalogv3.Profile) ([]Param, error) {
 			reader := bufio.NewReader(os.Stdin)
 			value, err := reader.ReadString('\n')
 			if err != nil {
-			    fmt.Printf("failed to read parameter %s: %v\n", param.Name, err)
+				fmt.Printf("failed to read parameter %s: %v\n", param.Name, err)
 				continue
 			}
 			value = value[:len(value)-1] // Trim the newline character
@@ -118,11 +139,11 @@ func ApplyParameters(appProfile *catalogv3.Profile) ([]Param, error) {
 	return namedParams, nil
 }
 
-func GetHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage, profileName string) ([]string, error) {
+func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName string, allParams bool) ([]string, error) {
 	if profileName == "" {
 		profileName = dp.DefaultProfileName
 	}
-	profile, err := FindDeploymentProfile(dp, profileName)
+	profile, err := r.FindDeploymentProfile(dp, profileName)
 	if err != nil {
 		return nil, err
 	}
@@ -131,11 +152,11 @@ func GetHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage, 
 
 	cmds := make([]string, 0)
 	for _, app := range dp.ApplicationReferences {
-		app, err := FindApp(r, app.Name, app.Version)
+		app, err := r.FindApp(app.Name, app.Version)
 		if err != nil {
 			return nil, err
 		}
-		reg, err := FindRegistry(r, app.HelmRegistryName)
+		reg, err := r.FindRegistry(app.HelmRegistryName)
 		if err != nil {
 			return nil, err
 		}
@@ -145,11 +166,11 @@ func GetHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage, 
 			namespace = "default"
 		}
 		appProfileName := profile.ApplicationProfiles[app.Name]
-		appProfile, err := FindAppProfile(app, appProfileName)
+		appProfile, err := r.FindAppProfile(app, appProfileName)
 		if err != nil {
 			return nil, err
 		}
-		namedParams, err := ApplyParameters(appProfile)
+		namedParams, err := r.ApplyParameters(appProfile, allParams)
 		if err != nil {
 			return nil, err
 		}
@@ -174,20 +195,6 @@ func GetHelmCommands(r *yamlreader.YamlReader, dp *catalogv3.DeploymentPackage, 
 }
 
 func mainCommand(cmd *cobra.Command, args []string) {
-	Overrides = make(map[string]string)
-    for _, override := range rawOverrides {
-		parts := strings.Split(override, "=")
-		if len(parts) != 2 {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
-		}
-		name := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if name == "" || value == "" {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
-		}
-		Overrides[name] = value
-	}
-
 	if len(args) != 1 {
 		err := cmd.Usage()
 		verboseerror.FatalErrCheck(err)
@@ -196,7 +203,10 @@ func mainCommand(cmd *cobra.Command, args []string) {
 
 	dir := args[0]
 
-	r := &yamlreader.YamlReader{}
+	r := &DpToHelm{}
+
+	r.SetOverrides(rawOverrides)
+
 	fileSet, err := r.ReadYamlFilesFromDir(dir)
 	verboseerror.FatalErrCheck(err)
 
@@ -226,7 +236,7 @@ func mainCommand(cmd *cobra.Command, args []string) {
 	}
 
 	for _, dp := range r.DeploymentPackages {
-		cmds, err := GetHelmCommands(r, dp, profile)
+		cmds, err := r.GetHelmCommands(dp, profile, allParams)
 		verboseerror.FatalErrCheck(err)
 		for _, cmd := range cmds {
 			fmt.Printf("%s\n", cmd)

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -54,11 +54,11 @@ func mainCommand(cmd *cobra.Command, args []string) {
 	}
 
 	if len(r.DeploymentPackages) == 0 {
-		verboseerror.FatalErrCheck(fmt.Errorf("no deployment packages found"))
+		verboseerror.FatalErrCheck(&dptohelm.DirectoryError{Msg: "no deployment packages found", InputDir: dir})
 	}
 
 	if len(r.DeploymentPackages) > 1 {
-		verboseerror.FatalErrCheck(fmt.Errorf("multiple deployment packages found"))
+		verboseerror.FatalErrCheck(&dptohelm.DirectoryError{Msg: "more than one deployment package found", InputDir: dir})
 	}
 
 	if listProfiles {

--- a/cmd/dp-to-helm/main.go
+++ b/cmd/dp-to-helm/main.go
@@ -5,14 +5,10 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"strings"
 
+	"github.com/open-edge-platform/app-orch-catalog/internal/dptohelm"
 	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
-	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
-	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/spf13/cobra"
 )
 
@@ -33,167 +29,6 @@ var (
 	}
 )
 
-type DpToHelm struct {
-	yamlreader.YamlReader
-	overrides map[string]string
-}
-
-func (r *DpToHelm) SetOverrides(rawOverrides []string) {
-	r.overrides = make(map[string]string)
-	for _, override := range rawOverrides {
-		parts := strings.Split(override, "=")
-		if len(parts) != 2 {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
-		}
-		name := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if name == "" || value == "" {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
-		}
-		r.overrides[name] = value
-	}
-}
-
-func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
-	for _, app := range r.Applications {
-		if app.Name == name && app.Version == version {
-			return app, nil
-		}
-	}
-	return nil, fmt.Errorf("application %s with version %s not found", name, version)
-}
-
-func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
-	for _, reg := range r.Registries {
-		if reg.Name == name {
-			return reg, nil
-		}
-	}
-	return nil, fmt.Errorf("registry %s not found", name)
-}
-
-func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
-	for _, profile := range dp.Profiles {
-		if profile.Name == name {
-			return profile, nil
-		}
-	}
-	return nil, fmt.Errorf("deployment profile %s not found", name)
-}
-
-func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
-	for _, appProfile := range app.Profiles {
-		if appProfile.Name == name {
-			return appProfile, nil
-		}
-	}
-	return nil, fmt.Errorf("application profile %s not found", name)
-}
-
-func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
-	namedParams := make([]Param, 0)
-	for _, param := range appProfile.ParameterTemplates {
-		// if param was overridden on the command line, use that value
-		override, ok := r.overrides[param.Name]
-		if ok {
-			namedParam := Param{
-				name:  param.Name,
-				value: override,
-			}
-			namedParams = append(namedParams, namedParam)
-			continue
-		}
-
-		// Mandatory parameters only, unless the user asked for everything
-		if !param.Mandatory && !allParams {
-			continue
-		}
-
-		for {
-			if param.Mandatory {
-				fmt.Printf("(mandatory) ")
-			}
-			fmt.Printf("Parameter %s [%s]: ", param.Name, param.Default)
-			reader := bufio.NewReader(os.Stdin)
-			value, err := reader.ReadString('\n')
-			if err != nil {
-				fmt.Printf("failed to read parameter %s: %v\n", param.Name, err)
-				continue
-			}
-			value = value[:len(value)-1] // Trim the newline character
-			if value == "" {
-				value = param.Default
-			}
-			if value == "" && param.Mandatory {
-				fmt.Printf("Parameter %s is mandatory, please provide a value\n", param.Name)
-				continue
-			}
-			namedParam := Param{
-				name:  param.Name,
-				value: value,
-			}
-			namedParams = append(namedParams, namedParam)
-			break
-		}
-	}
-	return namedParams, nil
-}
-
-func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName string, allParams bool) ([]string, error) {
-	if profileName == "" {
-		profileName = dp.DefaultProfileName
-	}
-	profile, err := r.FindDeploymentProfile(dp, profileName)
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Printf("# using deployment package profile: %s\n", profileName)
-
-	cmds := make([]string, 0)
-	for _, app := range dp.ApplicationReferences {
-		app, err := r.FindApp(app.Name, app.Version)
-		if err != nil {
-			return nil, err
-		}
-		reg, err := r.FindRegistry(app.HelmRegistryName)
-		if err != nil {
-			return nil, err
-		}
-		var namespace string
-		namespace, okay := dp.DefaultNamespaces[app.Name]
-		if !okay {
-			namespace = "default"
-		}
-		appProfileName := profile.ApplicationProfiles[app.Name]
-		appProfile, err := r.FindAppProfile(app, appProfileName)
-		if err != nil {
-			return nil, err
-		}
-		namedParams, err := r.ApplyParameters(appProfile, allParams)
-		if err != nil {
-			return nil, err
-		}
-		valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
-		err = os.WriteFile(valuesFileName, []byte(appProfile.ChartValues), 0644)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write to values file %s: %v", valuesFileName, err)
-		}
-		fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
-		url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)
-		helmCmd := fmt.Sprintf("helm install %s %s --version %s --namespace %s -f %s", app.Name, url, app.ChartVersion, namespace, valuesFileName)
-		for _, param := range namedParams {
-			helmCmd += fmt.Sprintf(" --set %s=\"%s\"", param.name, param.value)
-		}
-		if namespace != "default" {
-			cmds = append(cmds, fmt.Sprintf("kubectl create namespace %s || true", namespace))
-		}
-		cmds = append(cmds, helmCmd)
-	}
-
-	return cmds, nil
-}
-
 func mainCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		err := cmd.Usage()
@@ -203,7 +38,7 @@ func mainCommand(cmd *cobra.Command, args []string) {
 
 	dir := args[0]
 
-	r := &DpToHelm{}
+	r := &dptohelm.DpToHelm{}
 
 	r.SetOverrides(rawOverrides)
 

--- a/cmd/helm-to-dp/main.go
+++ b/cmd/helm-to-dp/main.go
@@ -31,7 +31,7 @@ from the Helm chart and store that package in an output directory`,
 func mainCommand(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		err := cmd.Usage()
-		verboseerror.FatalErrCheck(err, "Failed to print usage: %v", err)
+		verboseerror.FatalErrCheck(err)
 		return
 	}
 
@@ -43,10 +43,10 @@ func mainCommand(cmd *cobra.Command, args []string) {
 	url := args[0]
 
 	helm, err := helm.FetchHelmChartOCI(url, username, password)
-	verboseerror.FatalErrCheck(err, "Failed to fetch Helm chart: %v", err)
+	verboseerror.FatalErrCheck(err)
 
 	err = dp.GenerateDeploymentPackage(helm, valuesFile, outputDir, namespace, includeAuth)
-	verboseerror.FatalErrCheck(err, "Failed to generate Deployment Package: %v", err)
+	verboseerror.FatalErrCheck(err)
 }
 
 func main() {
@@ -60,5 +60,5 @@ func main() {
 	rootCmd.Run = mainCommand
 
 	err := rootCmd.Execute()
-	verboseerror.FatalErrCheck(err, "Failed to execute root command: %v", err)
+	verboseerror.FatalErrCheck(err)
 }

--- a/internal/dptohelm/dptohelm.go
+++ b/internal/dptohelm/dptohelm.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
 )
 
 type Param struct {
@@ -21,7 +22,61 @@ type Param struct {
 
 type DpToHelm struct {
 	yamlreader.YamlReader
-	overrides map[string]string
+	Applications       []*catalogv3.Application
+	DeploymentPackages []*catalogv3.DeploymentPackage
+	Registries         []*catalogv3.Registry
+	overrides          map[string]string
+}
+
+// ProcessFiles processes the given FileSet, loading its YAML files and
+// adding the resulting objects to the YamlReader object.
+
+func (u *DpToHelm) ProcessFiles(files yamlreader.FileSet) error {
+	// Process each FileSet, load its yaml, sort, and add to the catalog.
+
+	orderedSpecs, err := u.LoadYamlSpecs(files)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range orderedSpecs {
+		switch d.SpecSchema {
+		case upload.DeploymentPackageType:
+			dp, err := u.ReadDeploymentPackage(d)
+			if err != nil {
+				return err
+			}
+			u.DeploymentPackages = append(u.DeploymentPackages, dp)
+		case upload.DeploymentPackageLegacyType:
+			dp, err := u.ReadDeploymentPackage(d)
+			if err != nil {
+				return err
+			}
+			u.DeploymentPackages = append(u.DeploymentPackages, dp)
+		case upload.ApplicationType:
+			app, err := u.ReadApplication(d, files) // application uses the FileSet to lookup profiles
+			if err != nil {
+				return err
+			}
+			u.Applications = append(u.Applications, app)
+		case upload.RegistryType:
+			reg, err := u.ReadRegistry(d)
+			if err != nil {
+				return err
+			}
+			u.Registries = append(u.Registries, reg)
+		case upload.ArtifactType:
+			_, err = u.ReadArtifact(d)
+			if err != nil {
+				return err
+			}
+			// we don't use these for anything
+		default:
+			return &InputError{Msg: fmt.Sprintf("unhandled type %s", d.SpecSchema), InputFile: d.FileName}
+		}
+	}
+
+	return nil
 }
 
 func (r *DpToHelm) SetOverrides(rawOverrides []string) error {

--- a/internal/dptohelm/dptohelm.go
+++ b/internal/dptohelm/dptohelm.go
@@ -31,56 +31,56 @@ type DpToHelm struct {
 // ProcessFiles processes the given FileSet, loading its YAML files and
 // adding the resulting objects to the YamlReader object.
 
-func (u *DpToHelm) ProcessFiles(files yamlreader.FileSet) error {
+func (d *DpToHelm) ProcessFiles(files yamlreader.FileSet) error {
 	// Process each FileSet, load its yaml, sort, and add to the catalog.
 
-	orderedSpecs, err := u.LoadYamlSpecs(files)
+	orderedSpecs, err := d.LoadYamlSpecs(files)
 	if err != nil {
 		return err
 	}
 
-	for _, d := range orderedSpecs {
-		switch d.SpecSchema {
+	for _, spec := range orderedSpecs {
+		switch spec.SpecSchema {
 		case upload.DeploymentPackageType:
-			dp, err := u.ReadDeploymentPackage(d)
+			dp, err := d.ReadDeploymentPackage(spec)
 			if err != nil {
 				return err
 			}
-			u.DeploymentPackages = append(u.DeploymentPackages, dp)
+			d.DeploymentPackages = append(d.DeploymentPackages, dp)
 		case upload.DeploymentPackageLegacyType:
-			dp, err := u.ReadDeploymentPackage(d)
+			dp, err := d.ReadDeploymentPackage(spec)
 			if err != nil {
 				return err
 			}
-			u.DeploymentPackages = append(u.DeploymentPackages, dp)
+			d.DeploymentPackages = append(d.DeploymentPackages, dp)
 		case upload.ApplicationType:
-			app, err := u.ReadApplication(d, files) // application uses the FileSet to lookup profiles
+			app, err := d.ReadApplication(spec, files) // application uses the FileSet to lookup profiles
 			if err != nil {
 				return err
 			}
-			u.Applications = append(u.Applications, app)
+			d.Applications = append(d.Applications, app)
 		case upload.RegistryType:
-			reg, err := u.ReadRegistry(d)
+			reg, err := d.ReadRegistry(spec)
 			if err != nil {
 				return err
 			}
-			u.Registries = append(u.Registries, reg)
+			d.Registries = append(d.Registries, reg)
 		case upload.ArtifactType:
-			_, err = u.ReadArtifact(d)
+			_, err = d.ReadArtifact(spec)
 			if err != nil {
 				return err
 			}
 			// we don't use these for anything
 		default:
-			return &InputError{Msg: fmt.Sprintf("unhandled type %s", d.SpecSchema), InputFile: d.FileName}
+			return &InputError{Msg: fmt.Sprintf("unhandled type %s", spec.SpecSchema), InputFile: spec.FileName}
 		}
 	}
 
 	return nil
 }
 
-func (r *DpToHelm) SetOverrides(rawOverrides []string) error {
-	r.overrides = make(map[string]string)
+func (d *DpToHelm) SetOverrides(rawOverrides []string) error {
+	d.overrides = make(map[string]string)
 	for _, override := range rawOverrides {
 		parts := strings.Split(override, "=")
 		if len(parts) != 2 {
@@ -91,13 +91,13 @@ func (r *DpToHelm) SetOverrides(rawOverrides []string) error {
 		if name == "" || value == "" {
 			return &UsageError{Input: override, Msg: "invalid --set override format, expected <key>=<value>"}
 		}
-		r.overrides[name] = value
+		d.overrides[name] = value
 	}
 	return nil
 }
 
-func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
-	for _, app := range r.Applications {
+func (d *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
+	for _, app := range d.Applications {
 		if app.Name == name && app.Version == version {
 			return app, nil
 		}
@@ -105,8 +105,8 @@ func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error)
 	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "application", ObjectName: name, ObjectVersion: version}
 }
 
-func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
-	for _, reg := range r.Registries {
+func (d *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
+	for _, reg := range d.Registries {
 		if reg.Name == name {
 			return reg, nil
 		}
@@ -114,7 +114,7 @@ func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
 	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "registry", ObjectName: name}
 }
 
-func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
+func (d *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
 	for _, profile := range dp.Profiles {
 		if profile.Name == name {
 			return profile, nil
@@ -123,7 +123,7 @@ func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name s
 	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "deployment profile", ObjectName: name}
 }
 
-func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
+func (d *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
 	for _, appProfile := range app.Profiles {
 		if appProfile.Name == name {
 			return appProfile, nil
@@ -132,11 +132,11 @@ func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*cat
 	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "application profile", ObjectName: name, ApplicationName: app.Name}
 }
 
-func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
+func (d *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
 	namedParams := make([]Param, 0)
 	for _, param := range appProfile.ParameterTemplates {
 		// if param was overridden on the command line, use that value
-		override, ok := r.overrides[param.Name]
+		override, ok := d.overrides[param.Name]
 		if ok {
 			namedParam := Param{
 				name:  param.Name,
@@ -181,11 +181,11 @@ func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool
 	return namedParams, nil
 }
 
-func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName string, allParams bool) ([]string, error) {
+func (d *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName string, allParams bool) ([]string, error) {
 	if profileName == "" {
 		profileName = dp.DefaultProfileName
 	}
-	profile, err := r.FindDeploymentProfile(dp, profileName)
+	profile, err := d.FindDeploymentProfile(dp, profileName)
 	if err != nil {
 		return nil, err
 	}
@@ -194,11 +194,11 @@ func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName 
 
 	cmds := make([]string, 0)
 	for _, app := range dp.ApplicationReferences {
-		app, err := r.FindApp(app.Name, app.Version)
+		app, err := d.FindApp(app.Name, app.Version)
 		if err != nil {
 			return nil, err
 		}
-		reg, err := r.FindRegistry(app.HelmRegistryName)
+		reg, err := d.FindRegistry(app.HelmRegistryName)
 		if err != nil {
 			return nil, err
 		}
@@ -208,16 +208,16 @@ func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName 
 			namespace = "default"
 		}
 		appProfileName := profile.ApplicationProfiles[app.Name]
-		appProfile, err := r.FindAppProfile(app, appProfileName)
+		appProfile, err := d.FindAppProfile(app, appProfileName)
 		if err != nil {
 			return nil, err
 		}
-		namedParams, err := r.ApplyParameters(appProfile, allParams)
+		namedParams, err := d.ApplyParameters(appProfile, allParams)
 		if err != nil {
 			return nil, err
 		}
 		valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
-		err = os.WriteFile(valuesFileName, []byte(appProfile.ChartValues), 0644)
+		err = os.WriteFile(valuesFileName, []byte(appProfile.ChartValues), 0600)
 		if err != nil {
 			return nil, &OutputError{Msg: "failed to write values file", OutputFile: valuesFileName, Err: err}
 		}

--- a/internal/dptohelm/dptohelm.go
+++ b/internal/dptohelm/dptohelm.go
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dptohelm
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
+	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
+	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
+)
+
+type Param struct {
+	name  string
+	value string
+}
+
+type DpToHelm struct {
+	yamlreader.YamlReader
+	overrides map[string]string
+}
+
+func (r *DpToHelm) SetOverrides(rawOverrides []string) {
+	r.overrides = make(map[string]string)
+	for _, override := range rawOverrides {
+		parts := strings.Split(override, "=")
+		if len(parts) != 2 {
+			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+		}
+		name := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if name == "" || value == "" {
+			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+		}
+		r.overrides[name] = value
+	}
+}
+
+func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
+	for _, app := range r.Applications {
+		if app.Name == name && app.Version == version {
+			return app, nil
+		}
+	}
+	return nil, fmt.Errorf("application %s with version %s not found", name, version)
+}
+
+func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
+	for _, reg := range r.Registries {
+		if reg.Name == name {
+			return reg, nil
+		}
+	}
+	return nil, fmt.Errorf("registry %s not found", name)
+}
+
+func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
+	for _, profile := range dp.Profiles {
+		if profile.Name == name {
+			return profile, nil
+		}
+	}
+	return nil, fmt.Errorf("deployment profile %s not found", name)
+}
+
+func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
+	for _, appProfile := range app.Profiles {
+		if appProfile.Name == name {
+			return appProfile, nil
+		}
+	}
+	return nil, fmt.Errorf("application profile %s not found", name)
+}
+
+func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
+	namedParams := make([]Param, 0)
+	for _, param := range appProfile.ParameterTemplates {
+		// if param was overridden on the command line, use that value
+		override, ok := r.overrides[param.Name]
+		if ok {
+			namedParam := Param{
+				name:  param.Name,
+				value: override,
+			}
+			namedParams = append(namedParams, namedParam)
+			continue
+		}
+
+		// Mandatory parameters only, unless the user asked for everything
+		if !param.Mandatory && !allParams {
+			continue
+		}
+
+		for {
+			if param.Mandatory {
+				fmt.Printf("(mandatory) ")
+			}
+			fmt.Printf("Parameter %s [%s]: ", param.Name, param.Default)
+			reader := bufio.NewReader(os.Stdin)
+			value, err := reader.ReadString('\n')
+			if err != nil {
+				fmt.Printf("failed to read parameter %s: %v\n", param.Name, err)
+				continue
+			}
+			value = value[:len(value)-1] // Trim the newline character
+			if value == "" {
+				value = param.Default
+			}
+			if value == "" && param.Mandatory {
+				fmt.Printf("Parameter %s is mandatory, please provide a value\n", param.Name)
+				continue
+			}
+			namedParam := Param{
+				name:  param.Name,
+				value: value,
+			}
+			namedParams = append(namedParams, namedParam)
+			break
+		}
+	}
+	return namedParams, nil
+}
+
+func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName string, allParams bool) ([]string, error) {
+	if profileName == "" {
+		profileName = dp.DefaultProfileName
+	}
+	profile, err := r.FindDeploymentProfile(dp, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("# using deployment package profile: %s\n", profileName)
+
+	cmds := make([]string, 0)
+	for _, app := range dp.ApplicationReferences {
+		app, err := r.FindApp(app.Name, app.Version)
+		if err != nil {
+			return nil, err
+		}
+		reg, err := r.FindRegistry(app.HelmRegistryName)
+		if err != nil {
+			return nil, err
+		}
+		var namespace string
+		namespace, okay := dp.DefaultNamespaces[app.Name]
+		if !okay {
+			namespace = "default"
+		}
+		appProfileName := profile.ApplicationProfiles[app.Name]
+		appProfile, err := r.FindAppProfile(app, appProfileName)
+		if err != nil {
+			return nil, err
+		}
+		namedParams, err := r.ApplyParameters(appProfile, allParams)
+		if err != nil {
+			return nil, err
+		}
+		valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
+		err = os.WriteFile(valuesFileName, []byte(appProfile.ChartValues), 0644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to write to values file %s: %v", valuesFileName, err)
+		}
+		fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
+		url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)
+		helmCmd := fmt.Sprintf("helm install %s %s --version %s --namespace %s -f %s", app.Name, url, app.ChartVersion, namespace, valuesFileName)
+		for _, param := range namedParams {
+			helmCmd += fmt.Sprintf(" --set %s=\"%s\"", param.name, param.value)
+		}
+		if namespace != "default" {
+			cmds = append(cmds, fmt.Sprintf("kubectl create namespace %s || true", namespace))
+		}
+		cmds = append(cmds, helmCmd)
+	}
+
+	return cmds, nil
+}

--- a/internal/dptohelm/dptohelm.go
+++ b/internal/dptohelm/dptohelm.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
 	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 )
@@ -25,20 +24,21 @@ type DpToHelm struct {
 	overrides map[string]string
 }
 
-func (r *DpToHelm) SetOverrides(rawOverrides []string) {
+func (r *DpToHelm) SetOverrides(rawOverrides []string) error {
 	r.overrides = make(map[string]string)
 	for _, override := range rawOverrides {
 		parts := strings.Split(override, "=")
 		if len(parts) != 2 {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+			return &UsageError{Input: override, Msg: "invalid --set override format, expected <key>=<value>"}
 		}
 		name := strings.TrimSpace(parts[0])
 		value := strings.TrimSpace(parts[1])
 		if name == "" || value == "" {
-			verboseerror.FatalErrCheck(fmt.Errorf("invalid --set override format: %s, expected <key>=<value>", override))
+			return &UsageError{Input: override, Msg: "invalid --set override format, expected <key>=<value>"}
 		}
 		r.overrides[name] = value
 	}
+	return nil
 }
 
 func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error) {
@@ -47,7 +47,7 @@ func (r *DpToHelm) FindApp(name, version string) (*catalogv3.Application, error)
 			return app, nil
 		}
 	}
-	return nil, fmt.Errorf("application %s with version %s not found", name, version)
+	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "application", ObjectName: name, ObjectVersion: version}
 }
 
 func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
@@ -56,7 +56,7 @@ func (r *DpToHelm) FindRegistry(name string) (*catalogv3.Registry, error) {
 			return reg, nil
 		}
 	}
-	return nil, fmt.Errorf("registry %s not found", name)
+	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "registry", ObjectName: name}
 }
 
 func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name string) (*catalogv3.DeploymentProfile, error) {
@@ -65,7 +65,7 @@ func (r *DpToHelm) FindDeploymentProfile(dp *catalogv3.DeploymentPackage, name s
 			return profile, nil
 		}
 	}
-	return nil, fmt.Errorf("deployment profile %s not found", name)
+	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "deployment profile", ObjectName: name}
 }
 
 func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*catalogv3.Profile, error) {
@@ -74,7 +74,7 @@ func (r *DpToHelm) FindAppProfile(app *catalogv3.Application, name string) (*cat
 			return appProfile, nil
 		}
 	}
-	return nil, fmt.Errorf("application profile %s not found", name)
+	return nil, &NotFoundError{Msg: "Not Found", ObjectKind: "application profile", ObjectName: name, ApplicationName: app.Name}
 }
 
 func (r *DpToHelm) ApplyParameters(appProfile *catalogv3.Profile, allParams bool) ([]Param, error) {
@@ -164,7 +164,7 @@ func (r *DpToHelm) GetHelmCommands(dp *catalogv3.DeploymentPackage, profileName 
 		valuesFileName := fmt.Sprintf("%s-%s.yaml", app.Name, profileName)
 		err = os.WriteFile(valuesFileName, []byte(appProfile.ChartValues), 0644)
 		if err != nil {
-			return nil, fmt.Errorf("failed to write to values file %s: %v", valuesFileName, err)
+			return nil, &OutputError{Msg: "failed to write values file", OutputFile: valuesFileName, Err: err}
 		}
 		fmt.Printf("# created values file %s for app %s profile %s\n", valuesFileName, app.Name, appProfileName)
 		url := fmt.Sprintf("%s/%s", reg.RootUrl, app.ChartName)

--- a/internal/dptohelm/error.go
+++ b/internal/dptohelm/error.go
@@ -187,3 +187,42 @@ Package in it. There should be only one Deployment Package in the directory.
 func (e *DirectoryError) Unwrap() error {
 	return e.Err
 }
+
+// InputError is an error that occurs while reading input files
+
+type InputError struct {
+	InputFile string
+	Msg       string
+	Err       error
+}
+
+func (e *InputError) Error() string {
+	msg := fmt.Sprintf("%s while reading %s", e.Msg, e.InputFile)
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *InputError) Verbose(wr io.Writer) {
+	errTemplate := `------------------------------------------------------------
+A critical error was encountered
+------------------------------------------------------------
+{{ if .Msg -}}
+Message:       {{.Msg}}
+{{end -}}
+{{- if .InputFile -}}
+File:          {{.InputFile}}
+{{end -}}
+{{- if .Err -}}
+Wrapped Error: {{.Err}}
+{{end}}
+Recommendation: Please check that the files that you have specified exist and
+are readable by the current user.
+`
+	verboseerror.WriteErrorTemplate("InputError", errTemplate, wr, e)
+}
+
+func (e *InputError) Unwrap() error {
+	return e.Err
+}

--- a/internal/dptohelm/error.go
+++ b/internal/dptohelm/error.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dptohelm
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/open-edge-platform/app-orch-catalog/internal/shared/verboseerror"
+)
+
+// OutputError is an error that occurs while generating output files
+
+type UsageError struct {
+	Msg   string
+	Input string
+	Err   error
+}
+
+func (e *UsageError) Error() string {
+	msg := e.Msg
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *UsageError) Verbose(wr io.Writer) {
+	errTemplate := `------------------------------------------------------------
+A critical error was encountered
+------------------------------------------------------------
+{{ if .Msg -}}
+Message:       {{.Msg}}
+{{end -}}
+{{- if .Input-}}
+Input:         {{.Input}}
+{{end -}}
+{{- if .OutputFile -}}
+File:          {{.OutputFile}}
+{{end -}}
+{{- if .Err -}}
+Wrapped Error: {{.Err}}
+{{end}}
+Recommendation: Use -h to ensure that you are using the correct syntax.
+`
+	verboseerror.WriteErrorTemplate("UsageError", errTemplate, wr, e)
+}
+
+func (e *UsageError) Unwrap() error {
+	return e.Err
+}
+
+// InputError is an error that occurs while reading input files
+
+type NotFoundError struct {
+	Msg             string
+	ObjectKind      string
+	ObjectName      string
+	ObjectVersion   string
+	ApplicationName string
+	Err             error
+}
+
+func (e *NotFoundError) Error() string {
+	msg := fmt.Sprintf("%s on object %s value %s: %s", e.Msg, e.ObjectKind, e.ObjectName, e.Err)
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *NotFoundError) Verbose(wr io.Writer) {
+	errTemplate := `------------------------------------------------------------
+A critical error was encountered
+------------------------------------------------------------
+{{ if .Msg -}}
+Message:       {{.Msg}}
+{{end -}}
+{{- if .ObjectKind -}}
+Object:        {{.ObjectKind}}
+{{end -}}
+{{- if .ObjectName -}}
+Name:          {{.ObjectName}}
+{{end -}}
+{{- if .ObjectVersion -}}
+Version:       {{.ObjectVersion}}
+{{end -}}
+{{- if .ApplicationName -}}
+Name:          {{.ApplicationName}}
+{{end -}}
+{{- if .Err -}}
+Wrapped Error: {{.Err}}
+{{end}}
+This could indicate an internal inconsistency in the deployment package. Make sure the
+applications named inside your Deployment Package match the applications in your Application
+objects. Make sure versions are correct. Make sure profile names are correct. Make sure that
+any dependent objects, such as registries, are present in the DP.
+`
+	verboseerror.WriteErrorTemplate("NotFoundError", errTemplate, wr, e)
+}
+
+func (e *NotFoundError) Unwrap() error {
+	return e.Err
+}
+
+// OutputError is an error that occurs while generating output files
+
+type OutputError struct {
+	Msg        string
+	OutputFile string
+	OutputDir  string
+	Err        error
+}
+
+func (e *OutputError) Error() string {
+	msg := e.Msg
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *OutputError) Verbose(wr io.Writer) {
+	errTemplate := `------------------------------------------------------------
+A critical error was encountered
+------------------------------------------------------------
+{{ if .Msg -}}
+Message:       {{.Msg}}
+{{end -}}
+{{- if .OutputDir -}}
+Path:          {{.OutputDir}}
+{{end -}}
+{{- if .OutputFile -}}
+File:          {{.OutputFile}}
+{{end -}}
+{{- if .Err -}}
+Wrapped Error: {{.Err}}
+{{end}}
+Recommendation: Please check that the output path exists, is writable, has
+enough space and that you have sufficient permission to write files in that
+directory.
+`
+	verboseerror.WriteErrorTemplate("outputError", errTemplate, wr, e)
+}
+
+func (e *OutputError) Unwrap() error {
+	return e.Err
+}
+
+// DirectoryError is an error that occurs while reading input files
+
+type DirectoryError struct {
+	InputDir string
+	Msg      string
+	Err      error
+}
+
+func (e *DirectoryError) Error() string {
+	msg := fmt.Sprintf("%s while processing directory %s", e.Msg, e.InputDir)
+	if e.Err != nil {
+		msg = fmt.Sprintf("%s: %v", msg, e.Err)
+	}
+	return msg
+}
+
+func (e *DirectoryError) Verbose(wr io.Writer) {
+	errTemplate := `------------------------------------------------------------
+A critical error was encountered
+------------------------------------------------------------
+{{ if .Msg -}}
+Message:       {{.Msg}}
+{{end -}}
+{{- if .InputDir -}}
+Dir:          {{.InputDir}}
+{{end -}}
+{{- if .Err -}}
+Wrapped Error: {{.Err}}
+{{end}}
+Recommendation: Please ensure that the directory exists and has a valid Deployment
+Package in it. There should be only one Deployment Package in the directory.
+`
+	verboseerror.WriteErrorTemplate("DirectoryError", errTemplate, wr, e)
+}
+
+func (e *DirectoryError) Unwrap() error {
+	return e.Err
+}

--- a/internal/northbound/upload.go
+++ b/internal/northbound/upload.go
@@ -191,7 +191,7 @@ func (u *uploadSession) processUploadSession(ctx context.Context, tx *generated.
 	// fileSet independently.
 
 	for _, fileSet := range fileSets {
-		err := u.ProcessFiles(fileSet, ctx, tx)
+		err := u.ProcessFiles(ctx, fileSet, tx)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func (u *uploadSession) processUploadSession(ctx context.Context, tx *generated.
 	return nil
 }
 
-func (u *uploadSession) ProcessFiles(files yamlreader.FileSet, ctx context.Context, tx *generated.Tx) error {
+func (u *uploadSession) ProcessFiles(ctx context.Context, files yamlreader.FileSet, tx *generated.Tx) error {
 	// Process each FileSet, load its yaml, sort, and add to the catalog.
 
 	orderedSpecs, err := u.LoadYamlSpecs(files)
@@ -211,28 +211,33 @@ func (u *uploadSession) ProcessFiles(files yamlreader.FileSet, ctx context.Conte
 	for _, d := range orderedSpecs {
 		switch d.SpecSchema {
 		case upload.DeploymentPackageType:
-			dp, err := u.ReadDeploymentPackage(d)
-			if err != nil {
+			var dp *catalogv3.DeploymentPackage
+			dp, err = u.ReadDeploymentPackage(d)
+			if err == nil {
 				err = u.loadDeploymentPackage(ctx, tx, dp)
 			}
 		case upload.DeploymentPackageLegacyType:
-			dp, err := u.ReadDeploymentPackage(d)
-			if err != nil {
+			var dp *catalogv3.DeploymentPackage
+			dp, err = u.ReadDeploymentPackage(d)
+			if err == nil {
 				err = u.loadDeploymentPackage(ctx, tx, dp)
 			}
 		case upload.ApplicationType:
-			app, err := u.ReadApplication(d, files) // application uses the FileSet to lookup profiles
-			if err != nil {
-				err = u.loadApplication(ctx, tx, app, files)
+			var app *catalogv3.Application
+			app, err = u.ReadApplication(d, files) // application uses the FileSet to lookup profiles
+			if err == nil {
+				err = u.loadApplication(ctx, tx, app)
 			}
 		case upload.RegistryType:
-			reg, err := u.ReadRegistry(d)
-			if err != nil {
+			var reg *catalogv3.Registry
+			reg, err = u.ReadRegistry(d)
+			if err == nil {
 				err = u.loadRegistry(ctx, tx, reg)
 			}
 		case upload.ArtifactType:
-			art, err := u.ReadArtifact(d)
-			if err != nil {
+			var art *catalogv3.Artifact
+			art, err = u.ReadArtifact(d)
+			if err == nil {
 				err = u.loadArtifact(ctx, tx, art)
 			}
 		default:
@@ -264,7 +269,7 @@ func (u *uploadSession) loadArtifact(ctx context.Context, tx *generated.Tx, art 
 	return u.g.updateArtifact(ctx, tx, u.projectUUID, art, u.artifactEvents)
 }
 
-func (u *uploadSession) loadApplication(ctx context.Context, tx *generated.Tx, app *catalogv3.Application, f yamlreader.FileSet) error {
+func (u *uploadSession) loadApplication(ctx context.Context, tx *generated.Tx, app *catalogv3.Application) error {
 	_, err := tx.Application.Query().Where(application.ProjectUUID(u.projectUUID), application.Name(app.Name), application.Version(app.Version)).First(ctx)
 	if err != nil {
 		_, err = u.g.createApplication(ctx, tx, u.projectUUID, app, u.applicationEvents)

--- a/internal/northbound/upload.go
+++ b/internal/northbound/upload.go
@@ -15,22 +15,10 @@ package northbound
  */
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
-	b64 "encoding/base64"
-	"errors"
-	"fmt"
-	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
-	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
-	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/validator"
-	"io"
-	"path"
-	"regexp"
-	"sort"
-	"strings"
 	"sync"
+
+	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
 
 	"github.com/google/uuid"
 	"github.com/open-edge-platform/app-orch-catalog/internal/ent/generated"
@@ -38,21 +26,20 @@ import (
 	"github.com/open-edge-platform/app-orch-catalog/internal/ent/generated/artifact"
 	"github.com/open-edge-platform/app-orch-catalog/internal/ent/generated/deploymentpackage"
 	"github.com/open-edge-platform/app-orch-catalog/internal/ent/generated/registry"
+	"github.com/open-edge-platform/app-orch-catalog/internal/yamlreader"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/open-edge-platform/app-orch-catalog/pkg/malware"
-	yaml "gopkg.in/yaml.v3"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
 )
 
 const (
 	MaxExtractedFileSize = 10 * 1024 * 1024 // to limit the size of extracted files and mitigate decompression bomb lint message
 )
 
-// fileset is a map of file names to their contents. It is a set of files that should be evaluated
-// together. For example, it may contain applications and their profiles.
-type fileSet map[string][]byte
-
 // Structure to track multiple uploads for the same session
 type uploadSession struct {
+	yamlreader.YamlReader
+
 	sessionID   string
 	projectUUID string
 	lock        sync.RWMutex
@@ -186,195 +173,80 @@ func (g *Server) UploadCatalogEntities(ctx context.Context, req *catalogv3.Uploa
 }
 
 func (u *uploadSession) processUploadSession(ctx context.Context, tx *generated.Tx) error {
+	// Turn the uploaded file list into a FileSet, so we can pass it to ExpandFileSets
+	uploadedFiles := make(yamlreader.FileSet, 0)
+	for _, upload := range u.uploads {
+		uploadedFiles[upload.FileName] = upload.Artifact
+	}
+
 	// Turn the uploads into independent filesets. Each tarball will be a fileset, and
 	// any raw files will be collected into a fileset.
-	fileSets, err := u.loadFileSets()
+	fileSets, err := u.ExpandFileSet(uploadedFiles)
 	if err != nil {
 		return err
 	}
 
-	// Process each fileset, load its yaml, sort, and add to the catalog.
+	// fileSets now contains a set of fileSets, each one that is either a separate tarball
+	// that was uploaded, or is the set of raw yaml files that were uploaded. Process each
+	// fileSet independently.
+
 	for _, fileSet := range fileSets {
-		orderedSpecs, err := u.loadYamlSpecs(fileSet)
+		err := u.ProcessFiles(fileSet, ctx, tx)
 		if err != nil {
 			return err
-		}
-
-		for _, d := range orderedSpecs {
-			switch d.SpecSchema {
-			case upload.DeploymentPackageType:
-				err = u.loadDeploymentPackage(ctx, tx, d)
-			case upload.DeploymentPackageLegacyType:
-				err = u.loadDeploymentPackage(ctx, tx, d)
-			case upload.ApplicationType:
-				err = u.loadApplication(ctx, tx, d, fileSet) // application uses the fileSet to lookup profiles
-			case upload.RegistryType:
-				err = u.loadRegistry(ctx, tx, d)
-			case upload.ArtifactType:
-				err = u.loadArtifact(ctx, tx, d)
-			default:
-				return nberrors.NewInvalidArgument(nberrors.WithMessage("uploaded file %s: unhandled type %s", d.FileName, d.SpecSchema))
-			}
-			if err != nil {
-				return nberrors.NewInvalidArgument(nberrors.WithError(err), nberrors.WithMessage("uploaded file %s: %v", d.FileName, err))
-			}
 		}
 	}
 
 	return nil
 }
 
-// shouldValidateYAMLSchema determines if the schema checker should run on the given
-// artifact. If the YAML can be unmarshaled or contains the schema directive,
-// it should be validated. Values files containing {{ }} markers should
-// not be validated.
-func shouldValidateYAMLSchema(fileBytes []byte) bool {
-	var raw interface{}
-	err := yaml.Unmarshal(fileBytes, &raw)
+func (u *uploadSession) ProcessFiles(files yamlreader.FileSet, ctx context.Context, tx *generated.Tx) error {
+	// Process each FileSet, load its yaml, sort, and add to the catalog.
+
+	orderedSpecs, err := u.LoadYamlSpecs(files)
 	if err != nil {
-		re, _ := regexp.Compile(`\$schema:\s*"https://schema\.intel\.com/catalog\.orchestrator/0\.1/schema`)
-
-		if !re.MatchString(string(fileBytes)) {
-			return false
-		}
+		return err
 	}
-	return true
-}
 
-func (u *uploadSession) extractTarball(fileBytes []byte) (fileSet, error) {
-	contents := make(fileSet, 0)
-
-	// Convert fileBytes into an io.Reader
-	reader := bytes.NewReader(fileBytes)
-
-	// Create a gzip reader
-	gzipReader, err := gzip.NewReader(reader)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create gzip reader while extracting: %w", err)
-	}
-	defer gzipReader.Close()
-
-	// Create a tar reader
-	tarReader := tar.NewReader(gzipReader)
-
-	// Iterate through the files in the tar archive
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break // End of archive
+	for _, d := range orderedSpecs {
+		switch d.SpecSchema {
+		case upload.DeploymentPackageType:
+			dp, err := u.ReadDeploymentPackage(d)
+			if err != nil {
+				err = u.loadDeploymentPackage(ctx, tx, dp)
+			}
+		case upload.DeploymentPackageLegacyType:
+			dp, err := u.ReadDeploymentPackage(d)
+			if err != nil {
+				err = u.loadDeploymentPackage(ctx, tx, dp)
+			}
+		case upload.ApplicationType:
+			app, err := u.ReadApplication(d, files) // application uses the FileSet to lookup profiles
+			if err != nil {
+				err = u.loadApplication(ctx, tx, app, files)
+			}
+		case upload.RegistryType:
+			reg, err := u.ReadRegistry(d)
+			if err != nil {
+				err = u.loadRegistry(ctx, tx, reg)
+			}
+		case upload.ArtifactType:
+			art, err := u.ReadArtifact(d)
+			if err != nil {
+				err = u.loadArtifact(ctx, tx, art)
+			}
+		default:
+			return nberrors.NewInvalidArgument(nberrors.WithMessage("uploaded file %s: unhandled type %s", d.FileName, d.SpecSchema))
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read tar header while extracting: %w", err)
-		}
-
-		// Check if the current file is the one we want to extract
-		if header.Typeflag == tar.TypeReg {
-			// Read the file content into a buffer
-			var buf bytes.Buffer
-			if _, err := io.CopyN(&buf, tarReader, MaxExtractedFileSize); err != nil && err != io.EOF {
-				return nil, fmt.Errorf("Failed to copy file content while extracting: %w", err)
-			}
-
-			//verboseerror.Infof("Extracted file: %s\n", targetFileName)
-			contents[header.Name] = buf.Bytes()
+			return nberrors.NewInvalidArgument(nberrors.WithError(err), nberrors.WithMessage("uploaded file %s: %v", d.FileName, err))
 		}
 	}
 
-	return contents, nil
+	return nil
 }
 
-// loadYamlSpecs loads the contents of the specified uploads and returns them as an ordered
-// collection of YamlSpecs
-func (u *uploadSession) loadFileSets() ([]fileSet, error) {
-	var fileSets []fileSet
-
-	baseFileSet := make(fileSet, 0)
-
-	for _, file := range u.uploads {
-		if strings.HasSuffix(file.FileName, ".tgz") || strings.HasSuffix(file.FileName, ".tar.gz") {
-			// The file is a tarvball. Extract the individual files from it and add them to a fileset
-			extractedFileSet, err := u.extractTarball(file.Artifact)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract tarball %s: %w", file.FileName, err)
-			}
-			fileSets = append(fileSets, extractedFileSet)
-		} else {
-			// The file is a single YAML file. Add it to the base fileset
-			baseFileSet[file.FileName] = file.Artifact
-		}
-	}
-
-	if len(baseFileSet) > 0 {
-		// If we have a base file set, add it to the list of file sets
-		fileSets = append(fileSets, baseFileSet)
-	}
-
-	// We will validate the yaml contents inside of loadYamlSpecs()
-
-	return fileSets, nil
-}
-
-func (u *uploadSession) loadYamlSpecs(files fileSet) (upload.YamlSpecs, error) {
-	orderedSpecs := make(upload.YamlSpecs, 0)
-
-	for fileName, fileBytes := range files {
-		if shouldValidateYAMLSchema(fileBytes) {
-			// Deal only with files that can be successfully unmarshalled; value.yaml files with templates can't be for example
-			decoder := yaml.NewDecoder(bytes.NewBuffer(fileBytes))
-			for {
-				var d upload.YamlSpec
-				if err := decoder.Decode(&d); err != nil {
-					if errors.Is(err, io.EOF) {
-						break
-					}
-					return nil, fmt.Errorf("document decode failed: %w", err)
-				}
-				d.FileName = fileName
-				if d.SpecSchema != "" {
-					// check that the uploaded YAML complies with the schema
-					v, err := validator.NewValidator()
-					if err != nil {
-						return nil, err
-					}
-
-					err = v.Validate(fileBytes)
-					if err != nil {
-						log.Infof("YAML validation failed for %s:%s", fileName, err)
-						return nil, nberrors.NewInvalidArgument(
-							nberrors.WithMessage("uploaded file %s is invalid YAML: %+v", fileName, err),
-							nberrors.WithError(err))
-					}
-					orderedSpecs = append(orderedSpecs, d)
-				}
-			}
-		}
-	}
-
-	sort.Sort(orderedSpecs)
-	return orderedSpecs, nil
-}
-
-func valueOrDefault(val string, def string) string {
-	if val == "" {
-		return def
-	}
-	return val
-}
-
-func (u *uploadSession) loadRegistry(ctx context.Context, tx *generated.Tx, d upload.YamlSpec) error {
-	reg := &catalogv3.Registry{
-		Name:         d.Name,
-		DisplayName:  d.DisplayName,
-		Description:  d.Description,
-		RootUrl:      d.RootURL,
-		InventoryUrl: d.InventoryURL,
-		Username:     d.UserName,
-		AuthToken:    d.AuthToken,
-		Type:         valueOrDefault(d.GetRegistryType(), helmType),
-		ApiType:      d.APIType,
-		Cacerts:      d.CACerts,
-	}
-
+func (u *uploadSession) loadRegistry(ctx context.Context, tx *generated.Tx, reg *catalogv3.Registry) error {
 	_, err := tx.Registry.Query().Where(registry.ProjectUUID(u.projectUUID), registry.Name(reg.Name)).First(ctx)
 	if err != nil {
 		_, err = u.g.createRegistry(ctx, tx, u.projectUUID, reg, u.registryEvents)
@@ -383,41 +255,8 @@ func (u *uploadSession) loadRegistry(ctx context.Context, tx *generated.Tx, d up
 	return u.g.updateRegistry(ctx, tx, u.projectUUID, reg, u.registryEvents)
 }
 
-func (u *uploadSession) loadArtifact(ctx context.Context, tx *generated.Tx, d upload.YamlSpec) error {
-	artifactBinary, err := b64.StdEncoding.DecodeString(d.Artifact)
-	if err != nil {
-		return nberrors.NewInvalidArgument(
-			nberrors.WithResourceType(nberrors.ArtifactType),
-			nberrors.WithMessage("error decoding base64 from file %s %v", d.FileName, err))
-	}
-	if malware.DefaultScanner != nil {
-		// Note: Artifact Size is already limited by protobuf validator
-		okay, res, err := malware.DefaultScanner.ScanBytes(artifactBinary)
-		if err != nil {
-			if malware.DefaultScanner.IsPermissive() {
-				log.Warn("Malware scanner is not available. Skipping scan due to permissive mode.")
-			} else {
-				log.Warn("Malware scanner returned error %s", err)
-				return nberrors.NewUnavailable(
-					nberrors.WithResourceType(nberrors.ArtifactType),
-					nberrors.WithMessage("malware scanner configured but not available"))
-			}
-		} else if !okay {
-			return nberrors.NewInvalidArgument(
-				nberrors.WithResourceType(nberrors.ArtifactType),
-				nberrors.WithMessage("malware detected: %s", res))
-		}
-	}
-
-	art := &catalogv3.Artifact{
-		Name:        d.Name,
-		DisplayName: d.DisplayName,
-		Description: d.Description,
-		MimeType:    d.MimeType,
-		Artifact:    artifactBinary,
-	}
-
-	_, err = tx.Artifact.Query().Where(artifact.ProjectUUID(u.projectUUID), artifact.Name(art.Name)).First(ctx)
+func (u *uploadSession) loadArtifact(ctx context.Context, tx *generated.Tx, art *catalogv3.Artifact) error {
+	_, err := tx.Artifact.Query().Where(artifact.ProjectUUID(u.projectUUID), artifact.Name(art.Name)).First(ctx)
 	if err != nil {
 		_, err = u.g.createArtifact(ctx, tx, u.projectUUID, art, u.artifactEvents)
 		return err
@@ -425,45 +264,7 @@ func (u *uploadSession) loadArtifact(ctx context.Context, tx *generated.Tx, d up
 	return u.g.updateArtifact(ctx, tx, u.projectUUID, art, u.artifactEvents)
 }
 
-func (u *uploadSession) loadApplication(ctx context.Context, tx *generated.Tx, d upload.YamlSpec, f fileSet) error {
-	app := &catalogv3.Application{
-		Name:               d.Name,
-		Version:            d.Version,
-		Kind:               kindFromDB(d.Kind),
-		DisplayName:        d.DisplayName,
-		Description:        d.Description,
-		ChartName:          d.ChartName,
-		ChartVersion:       d.ChartVersion,
-		HelmRegistryName:   d.GetHelmRegistry(),
-		ImageRegistryName:  d.ImageRegistry,
-		DefaultProfileName: d.DefaultProfile,
-		Profiles:           make([]*catalogv3.Profile, 0, len(d.Profiles)),
-		IgnoredResources:   make([]*catalogv3.ResourceReference, 0, len(d.IgnoredResources)),
-	}
-
-	if len(d.Profiles) > 0 {
-		for _, p := range d.Profiles {
-			prof, err := u.loadProfile(d.FileName, p, f)
-			if err != nil {
-				return err
-			}
-			app.Profiles = append(app.Profiles, prof)
-		}
-		if app.DefaultProfileName == "" {
-			app.DefaultProfileName = d.Profiles[0].Name
-		}
-	}
-
-	if len(d.IgnoredResources) > 0 {
-		for _, r := range d.IgnoredResources {
-			app.IgnoredResources = append(app.IgnoredResources, &catalogv3.ResourceReference{
-				Name:      r.Name,
-				Kind:      r.Kind,
-				Namespace: r.Namespace,
-			})
-		}
-	}
-
+func (u *uploadSession) loadApplication(ctx context.Context, tx *generated.Tx, app *catalogv3.Application, f yamlreader.FileSet) error {
 	_, err := tx.Application.Query().Where(application.ProjectUUID(u.projectUUID), application.Name(app.Name), application.Version(app.Version)).First(ctx)
 	if err != nil {
 		_, err = u.g.createApplication(ctx, tx, u.projectUUID, app, u.applicationEvents)
@@ -472,161 +273,7 @@ func (u *uploadSession) loadApplication(ctx context.Context, tx *generated.Tx, d
 	return u.g.updateApplication(ctx, tx, u.projectUUID, app, u.applicationEvents)
 }
 
-func (u *uploadSession) loadProfile(appFileName string, p upload.Profile, f fileSet) (*catalogv3.Profile, error) {
-	fileBytes, ok := f[p.ValuesFileName]
-	if !ok {
-		fileBytes, ok = f[fmt.Sprintf("%s/%s", path.Dir(appFileName), p.ValuesFileName)]
-		if !ok {
-			return nil, nberrors.NewInvalidArgument(
-				nberrors.WithMessage("chart values file %s not found in uploads", p.ValuesFileName))
-		}
-	}
-
-	requirements := make([]*catalogv3.DeploymentRequirement, 0)
-	for _, dr := range p.DeploymentRequirements {
-		newRequirement := &catalogv3.DeploymentRequirement{
-			Name:                  dr.Name,
-			Version:               dr.Version,
-			DeploymentProfileName: dr.DeploymentProfile,
-		}
-		requirements = append(requirements, newRequirement)
-	}
-
-	parameterTemplates := make([]*catalogv3.ParameterTemplate, 0)
-	for _, pt := range p.ParameterTemplates {
-		newParameterTemplate := &catalogv3.ParameterTemplate{
-			Name:            pt.Name,
-			DisplayName:     pt.DisplayName,
-			Default:         pt.Default,
-			Type:            pt.Type,
-			Validator:       pt.Validator,
-			SuggestedValues: pt.SuggestedValues,
-			Secret:          pt.Secret,
-			Mandatory:       pt.Mandatory,
-		}
-		parameterTemplates = append(parameterTemplates, newParameterTemplate)
-	}
-
-	yamlString := string(fileBytes)
-	return &catalogv3.Profile{
-		Name:                  p.Name,
-		DisplayName:           p.DisplayName,
-		Description:           p.Description,
-		ChartValues:           yamlString,
-		DeploymentRequirement: requirements,
-		ParameterTemplates:    parameterTemplates,
-	}, nil
-}
-
-func (u *uploadSession) loadDeploymentPackage(ctx context.Context, tx *generated.Tx, d upload.YamlSpec) error {
-	pkg := &catalogv3.DeploymentPackage{
-		Name:                    d.Name,
-		DisplayName:             d.DisplayName,
-		Description:             d.Description,
-		Version:                 d.Version,
-		Kind:                    kindFromDB(d.Kind),
-		DefaultProfileName:      d.DefaultProfile,
-		Profiles:                make([]*catalogv3.DeploymentProfile, 0, len(d.DeploymentProfiles)),
-		ApplicationReferences:   make([]*catalogv3.ApplicationReference, 0, len(d.Applications)),
-		ApplicationDependencies: make([]*catalogv3.ApplicationDependency, 0, len(d.ApplicationDependencies)),
-		Extensions:              make([]*catalogv3.APIExtension, 0, len(d.Extensions)),
-		Artifacts:               make([]*catalogv3.ArtifactReference, 0, len(d.ArtifactReferences)),
-		DefaultNamespaces:       make(map[string]string, len(d.DefaultNamespaces)),
-		Namespaces:              make([]*catalogv3.Namespace, 0, len(d.Namespaces)),
-	}
-
-	for _, a := range d.Applications {
-		pkg.ApplicationReferences = append(pkg.ApplicationReferences,
-			&catalogv3.ApplicationReference{
-				Name:    a.Name,
-				Version: a.Version,
-			})
-	}
-
-	for _, e := range d.Extensions {
-		var endpoints []*catalogv3.Endpoint
-		for _, ep := range e.Endpoints {
-			endpoints = append(endpoints,
-				&catalogv3.Endpoint{
-					ServiceName:  ep.ServiceName,
-					ExternalPath: ep.ExternalPath,
-					InternalPath: ep.InternalPath,
-					Scheme:       ep.Scheme,
-					AuthType:     ep.AuthType,
-					AppName:      ep.AppName,
-				})
-		}
-		var uiExtension *catalogv3.UIExtension
-		if e.UIExtension != nil {
-			uiExtension =
-				&catalogv3.UIExtension{
-					ServiceName: e.UIExtension.ServiceName,
-					Label:       *e.UIExtension.Label,
-					Description: e.UIExtension.Description,
-					FileName:    e.UIExtension.FileName,
-					AppName:     e.UIExtension.AppName,
-					ModuleName:  e.UIExtension.ModuleName,
-				}
-		}
-		pkg.Extensions = append(pkg.Extensions,
-			&catalogv3.APIExtension{
-				Name:        e.Name,
-				Version:     e.Version,
-				DisplayName: e.DisplayName,
-				Description: e.Description,
-				Endpoints:   endpoints,
-				UiExtension: uiExtension,
-			})
-	}
-
-	for _, a := range d.GetArtifacts() {
-		pkg.Artifacts = append(pkg.Artifacts,
-			&catalogv3.ArtifactReference{
-				Name:    a.Name,
-				Purpose: a.Purpose,
-			})
-	}
-
-	if len(d.ApplicationDependencies) > 0 {
-		for _, a := range d.ApplicationDependencies {
-			pkg.ApplicationDependencies = append(pkg.ApplicationDependencies,
-				&catalogv3.ApplicationDependency{
-					Name:     a.Name,
-					Requires: a.Requires,
-				})
-		}
-	}
-
-	if len(d.DefaultNamespaces) != 0 {
-		for k, v := range d.DefaultNamespaces {
-			pkg.DefaultNamespaces[k] = v
-		}
-	}
-
-	if len(d.Namespaces) != 0 {
-		for _, ns := range d.Namespaces {
-			pkg.Namespaces = append(pkg.Namespaces,
-				&catalogv3.Namespace{
-					Name:        ns.Name,
-					Labels:      ns.Labels,
-					Annotations: ns.Annotations,
-				})
-		}
-	}
-
-	if len(d.DeploymentProfiles) > 0 {
-		for _, profile := range d.DeploymentProfiles {
-			pkg.Profiles = append(pkg.Profiles, u.deploymentProfile(profile))
-		}
-		if pkg.DefaultProfileName == "" {
-			pkg.DefaultProfileName = d.DeploymentProfiles[0].Name
-		}
-	}
-
-	pkg.IsVisible = d.IsVisible
-	pkg.IsDeployed = d.IsDeployed
-	pkg.ForbidsMultipleDeployments = d.ForbidsMultipleDeployments
-
+func (u *uploadSession) loadDeploymentPackage(ctx context.Context, tx *generated.Tx, pkg *catalogv3.DeploymentPackage) error {
 	_, err := tx.DeploymentPackage.Query().Where(deploymentpackage.ProjectUUID(u.projectUUID),
 		deploymentpackage.Name(pkg.Name), deploymentpackage.Version(pkg.Version)).First(ctx)
 	if err != nil {
@@ -634,18 +281,4 @@ func (u *uploadSession) loadDeploymentPackage(ctx context.Context, tx *generated
 		return err
 	}
 	return u.g.updateDeploymentPackage(ctx, tx, u.projectUUID, pkg, u.deploymentPackageEvents)
-}
-
-func (u *uploadSession) deploymentProfile(deploymentProfile upload.DeploymentProfile) *catalogv3.DeploymentProfile {
-	prof := &catalogv3.DeploymentProfile{
-		Name:                deploymentProfile.Name,
-		DisplayName:         deploymentProfile.DisplayName,
-		Description:         deploymentProfile.Description,
-		ApplicationProfiles: make(map[string]string, len(deploymentProfile.ApplicationProfiles)),
-	}
-
-	for _, p := range deploymentProfile.ApplicationProfiles {
-		prof.ApplicationProfiles[p.ApplicationName] = p.ProfileName
-	}
-	return prof
 }

--- a/internal/northbound/upload_test.go
+++ b/internal/northbound/upload_test.go
@@ -6,12 +6,12 @@ package northbound
 
 import (
 	"context"
+	"os"
+	"time"
+
 	internaltesting "github.com/open-edge-platform/app-orch-catalog/internal/testing"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/open-edge-platform/app-orch-catalog/pkg/malware"
-	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
-	"os"
-	"time"
 )
 
 func (s *NorthBoundTestSuite) getUpload(fileName string) *catalogv3.Upload {
@@ -319,7 +319,7 @@ func (s *NorthBoundTestSuite) TestStrictMalwareFailure() {
 
 func (s *NorthBoundTestSuite) TestArtifactMalwareScanError() {
 	u := &uploadSession{}
-	d := upload.YamlSpec{}
+	d := &catalogv3.Artifact{}
 
 	malware.DefaultScanner = malware.NewScanner(":1123", time.Duration(5)*time.Second, false)
 	defer func() {

--- a/internal/shared/verboseerror/verboseerror.go
+++ b/internal/shared/verboseerror/verboseerror.go
@@ -36,11 +36,8 @@ func Fatalf(format string, args ...interface{}) {
 // FatalErrCheck checks the error and prints a formatted message to stderr if the
 // error is not nil. It then prints the error and exits.
 
-func FatalErrCheck(err error, format string, args ...interface{}) {
+func FatalErrCheck(err error) {
 	if err != nil {
-		if format != "" {
-			fmt.Fprintf(os.Stderr, format, args...)
-		}
 		PrintVerboseError(err)
 		os.Exit(1)
 	}
@@ -75,5 +72,5 @@ func WriteErrorTemplate(templateName string, templateContents string, wr io.Writ
 	err := template.Must(template.New(templateName).Parse(templateContents)).Execute(wr, e)
 
 	/* if we failed to render the template, then fatal exit */
-	FatalErrCheck(err, "Failed to render error template: %v", err)
+	FatalErrCheck(fmt.Errorf("Failed to render error template: %v", err))
 }

--- a/internal/yamlreader/yamlreader.go
+++ b/internal/yamlreader/yamlreader.go
@@ -10,7 +10,6 @@ import (
 	"compress/gzip"
 	b64 "encoding/base64"
 	"errors"
-	"path/filepath"
 	"fmt"
 	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
 	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
@@ -18,29 +17,30 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/open-edge-platform/orch-library/go/dazl"
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/open-edge-platform/app-orch-catalog/pkg/malware"
+	"github.com/open-edge-platform/orch-library/go/dazl"
 	yaml "gopkg.in/yaml.v3"
 )
 
 const (
 	MaxExtractedFileSize = 10 * 1024 * 1024 // to limit the size of extracted files and mitigate decompression bomb lint message
-	kindNormal    = "normal"
-	kindAddon     = "addon"
-	kindExtension = "extension"
-	helmType  = "HELM"
+	kindNormal           = "normal"
+	kindAddon            = "addon"
+	kindExtension        = "extension"
+	helmType             = "HELM"
 )
 
 type YamlReader struct {
-	Applications		[]*catalogv3.Application
-	DeploymentPackages 	[]*catalogv3.DeploymentPackage
-	Artifacts			[]*catalogv3.Artifact
-	Registries			[]*catalogv3.Registry
+	Applications       []*catalogv3.Application
+	DeploymentPackages []*catalogv3.DeploymentPackage
+	Artifacts          []*catalogv3.Artifact
+	Registries         []*catalogv3.Registry
 }
 
 // fileSet is a map of file names to their contents. It is a set of files that should be evaluated
@@ -52,11 +52,11 @@ var log dazl.Logger
 func kindFromDB(kind string) catalogv3.Kind {
 	switch kind {
 	case kindNormal:
-			return catalogv3.Kind_KIND_NORMAL
+		return catalogv3.Kind_KIND_NORMAL
 	case kindAddon:
-			return catalogv3.Kind_KIND_ADDON
+		return catalogv3.Kind_KIND_ADDON
 	case kindExtension:
-			return catalogv3.Kind_KIND_EXTENSION
+		return catalogv3.Kind_KIND_EXTENSION
 	}
 	return catalogv3.Kind_KIND_NORMAL
 }
@@ -131,7 +131,6 @@ func (u *YamlReader) ProcessFiles(files fileSet) error {
 			return nberrors.NewInvalidArgument(nberrors.WithError(err), nberrors.WithMessage("uploaded file %s: %v", d.FileName, err))
 		}
 	}
-
 
 	return nil
 }

--- a/internal/yamlreader/yamlreader.go
+++ b/internal/yamlreader/yamlreader.go
@@ -1,0 +1,546 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package yamlreader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	b64 "encoding/base64"
+	"errors"
+	"path/filepath"
+	"fmt"
+	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/validator"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/open-edge-platform/orch-library/go/dazl"
+	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/malware"
+	yaml "gopkg.in/yaml.v3"
+)
+
+const (
+	MaxExtractedFileSize = 10 * 1024 * 1024 // to limit the size of extracted files and mitigate decompression bomb lint message
+	kindNormal    = "normal"
+	kindAddon     = "addon"
+	kindExtension = "extension"
+	helmType  = "HELM"
+)
+
+type YamlReader struct {
+	Applications		[]*catalogv3.Application
+	DeploymentPackages 	[]*catalogv3.DeploymentPackage
+	Artifacts			[]*catalogv3.Artifact
+	Registries			[]*catalogv3.Registry
+}
+
+// fileSet is a map of file names to their contents. It is a set of files that should be evaluated
+// together. For example, it may contain applications and their profiles.
+type fileSet map[string][]byte
+
+var log dazl.Logger
+
+func kindFromDB(kind string) catalogv3.Kind {
+	switch kind {
+	case kindNormal:
+			return catalogv3.Kind_KIND_NORMAL
+	case kindAddon:
+			return catalogv3.Kind_KIND_ADDON
+	case kindExtension:
+			return catalogv3.Kind_KIND_EXTENSION
+	}
+	return catalogv3.Kind_KIND_NORMAL
+}
+
+func (u *YamlReader) ReadYamlFilesFromDir(dir string) (fileSet, error) {
+	files := make(fileSet)
+
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("directory %s does not exist", dir)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to access directory %s: %v", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path %s is not a directory", dir)
+	}
+
+	direntries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %v", dir, err)
+	}
+
+	for _, direntry := range direntries {
+		if !direntry.IsDir() && (filepath.Ext(direntry.Name()) == ".yaml" || filepath.Ext(direntry.Name()) == ".yml") {
+			filename := filepath.Join(dir, direntry.Name())
+			file, err := os.Open(filename)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open file %s: %v", filename, err)
+			}
+			defer file.Close()
+			content, err := io.ReadAll(file)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read file %s: %v", filename, err)
+			}
+			files[path.Base(filename)] = content
+
+		}
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no YAML files found in directory %s", dir)
+	}
+
+	return files, nil
+}
+
+func (u *YamlReader) ProcessFiles(files fileSet) error {
+	// Process each fileset, load its yaml, sort, and add to the catalog.
+
+	orderedSpecs, err := u.loadYamlSpecs(files)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range orderedSpecs {
+		switch d.SpecSchema {
+		case upload.DeploymentPackageType:
+			err = u.readDeploymentPackage(d)
+		case upload.DeploymentPackageLegacyType:
+			err = u.readDeploymentPackage(d)
+		case upload.ApplicationType:
+			err = u.readApplication(d, files) // application uses the fileSet to lookup profiles
+		case upload.RegistryType:
+			err = u.readRegistry(d)
+		case upload.ArtifactType:
+			err = u.readArtifact(d)
+		default:
+			return nberrors.NewInvalidArgument(nberrors.WithMessage("uploaded file %s: unhandled type %s", d.FileName, d.SpecSchema))
+		}
+		if err != nil {
+			return nberrors.NewInvalidArgument(nberrors.WithError(err), nberrors.WithMessage("uploaded file %s: %v", d.FileName, err))
+		}
+	}
+
+
+	return nil
+}
+
+// shouldValidateYAMLSchema determines if the schema checker should run on the given
+// artifact. If the YAML can be unmarshaled or contains the schema directive,
+// it should be validated. Values files containing {{ }} markers should
+// not be validated.
+func shouldValidateYAMLSchema(fileBytes []byte) bool {
+	var raw interface{}
+	err := yaml.Unmarshal(fileBytes, &raw)
+	if err != nil {
+		re, _ := regexp.Compile(`\$schema:\s*"https://schema\.intel\.com/catalog\.orchestrator/0\.1/schema`)
+
+		if !re.MatchString(string(fileBytes)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (u *YamlReader) extractTarball(fileBytes []byte) (fileSet, error) {
+	contents := make(fileSet, 0)
+
+	// Convert fileBytes into an io.Reader
+	reader := bytes.NewReader(fileBytes)
+
+	// Create a gzip reader
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create gzip reader while extracting: %w", err)
+	}
+	defer gzipReader.Close()
+
+	// Create a tar reader
+	tarReader := tar.NewReader(gzipReader)
+
+	// Iterate through the files in the tar archive
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read tar header while extracting: %w", err)
+		}
+
+		// Check if the current file is the one we want to extract
+		if header.Typeflag == tar.TypeReg {
+			// Read the file content into a buffer
+			var buf bytes.Buffer
+			if _, err := io.CopyN(&buf, tarReader, MaxExtractedFileSize); err != nil && err != io.EOF {
+				return nil, fmt.Errorf("Failed to copy file content while extracting: %w", err)
+			}
+
+			//verboseerror.Infof("Extracted file: %s\n", targetFileName)
+			contents[header.Name] = buf.Bytes()
+		}
+	}
+
+	return contents, nil
+}
+
+// loadYamlSpecs loads the contents of the specified uploads and returns them as an ordered
+// collection of YamlSpecs
+func (u *YamlReader) ExpandFileSet(srcFiles fileSet) ([]fileSet, error) {
+	var fileSets []fileSet
+
+	baseFileSet := make(fileSet, 0)
+
+	for fileName, fileContents := range srcFiles {
+		if strings.HasSuffix(fileName, ".tgz") || strings.HasSuffix(fileName, ".tar.gz") {
+			// The file is a tarvball. Extract the individual files from it and add them to a fileset
+			extractedFileSet, err := u.extractTarball(fileContents)
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract tarball %s: %w", fileName, err)
+			}
+			fileSets = append(fileSets, extractedFileSet)
+		} else {
+			// The file is a single YAML file. Add it to the base fileset
+			baseFileSet[fileName] = fileContents
+		}
+	}
+
+	if len(baseFileSet) > 0 {
+		// If we have a base file set, add it to the list of file sets
+		fileSets = append(fileSets, baseFileSet)
+	}
+
+	// We will validate the yaml contents inside of loadYamlSpecs()
+
+	return fileSets, nil
+}
+
+func (u *YamlReader) loadYamlSpecs(files fileSet) (upload.YamlSpecs, error) {
+	orderedSpecs := make(upload.YamlSpecs, 0)
+
+	for fileName, fileBytes := range files {
+		if shouldValidateYAMLSchema(fileBytes) {
+			// Deal only with files that can be successfully unmarshalled; value.yaml files with templates can't be for example
+			decoder := yaml.NewDecoder(bytes.NewBuffer(fileBytes))
+			for {
+				var d upload.YamlSpec
+				if err := decoder.Decode(&d); err != nil {
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					return nil, fmt.Errorf("document decode failed: %w", err)
+				}
+				d.FileName = fileName
+				if d.SpecSchema != "" {
+					// check that the uploaded YAML complies with the schema
+					v, err := validator.NewValidator()
+					if err != nil {
+						return nil, err
+					}
+
+					err = v.Validate(fileBytes)
+					if err != nil {
+						log.Infof("YAML validation failed for %s:%s", fileName, err)
+						return nil, nberrors.NewInvalidArgument(
+							nberrors.WithMessage("uploaded file %s is invalid YAML: %+v", fileName, err),
+							nberrors.WithError(err))
+					}
+					orderedSpecs = append(orderedSpecs, d)
+				}
+			}
+		}
+	}
+
+	sort.Sort(orderedSpecs)
+	return orderedSpecs, nil
+}
+
+func valueOrDefault(val string, def string) string {
+	if val == "" {
+		return def
+	}
+	return val
+}
+
+func (u *YamlReader) readRegistry(d upload.YamlSpec) error {
+	reg := &catalogv3.Registry{
+		Name:         d.Name,
+		DisplayName:  d.DisplayName,
+		Description:  d.Description,
+		RootUrl:      d.RootURL,
+		InventoryUrl: d.InventoryURL,
+		Username:     d.UserName,
+		AuthToken:    d.AuthToken,
+		Type:         valueOrDefault(d.GetRegistryType(), helmType),
+		ApiType:      d.APIType,
+		Cacerts:      d.CACerts,
+	}
+
+	u.Registries = append(u.Registries, reg)
+	return nil
+}
+
+func (u *YamlReader) readArtifact(d upload.YamlSpec) error {
+	artifactBinary, err := b64.StdEncoding.DecodeString(d.Artifact)
+	if err != nil {
+		return nberrors.NewInvalidArgument(
+			nberrors.WithResourceType(nberrors.ArtifactType),
+			nberrors.WithMessage("error decoding base64 from file %s %v", d.FileName, err))
+	}
+	if malware.DefaultScanner != nil {
+		// Note: Artifact Size is already limited by protobuf validator
+		okay, res, err := malware.DefaultScanner.ScanBytes(artifactBinary)
+		if err != nil {
+			if malware.DefaultScanner.IsPermissive() {
+				log.Warn("Malware scanner is not available. Skipping scan due to permissive mode.")
+			} else {
+				log.Warn("Malware scanner returned error %s", err)
+				return nberrors.NewUnavailable(
+					nberrors.WithResourceType(nberrors.ArtifactType),
+					nberrors.WithMessage("malware scanner configured but not available"))
+			}
+		} else if !okay {
+			return nberrors.NewInvalidArgument(
+				nberrors.WithResourceType(nberrors.ArtifactType),
+				nberrors.WithMessage("malware detected: %s", res))
+		}
+	}
+
+	art := &catalogv3.Artifact{
+		Name:        d.Name,
+		DisplayName: d.DisplayName,
+		Description: d.Description,
+		MimeType:    d.MimeType,
+		Artifact:    artifactBinary,
+	}
+
+	u.Artifacts = append(u.Artifacts, art)
+	return nil
+}
+
+func (u *YamlReader) readApplication(d upload.YamlSpec, f fileSet) error {
+	app := &catalogv3.Application{
+		Name:               d.Name,
+		Version:            d.Version,
+		Kind:               kindFromDB(d.Kind),
+		DisplayName:        d.DisplayName,
+		Description:        d.Description,
+		ChartName:          d.ChartName,
+		ChartVersion:       d.ChartVersion,
+		HelmRegistryName:   d.GetHelmRegistry(),
+		ImageRegistryName:  d.ImageRegistry,
+		DefaultProfileName: d.DefaultProfile,
+		Profiles:           make([]*catalogv3.Profile, 0, len(d.Profiles)),
+		IgnoredResources:   make([]*catalogv3.ResourceReference, 0, len(d.IgnoredResources)),
+	}
+
+	if len(d.Profiles) > 0 {
+		for _, p := range d.Profiles {
+			prof, err := u.readProfile(d.FileName, p, f)
+			if err != nil {
+				return err
+			}
+			app.Profiles = append(app.Profiles, prof)
+		}
+		if app.DefaultProfileName == "" {
+			app.DefaultProfileName = d.Profiles[0].Name
+		}
+	}
+
+	if len(d.IgnoredResources) > 0 {
+		for _, r := range d.IgnoredResources {
+			app.IgnoredResources = append(app.IgnoredResources, &catalogv3.ResourceReference{
+				Name:      r.Name,
+				Kind:      r.Kind,
+				Namespace: r.Namespace,
+			})
+		}
+	}
+
+	u.Applications = append(u.Applications, app)
+	return nil
+}
+
+func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f fileSet) (*catalogv3.Profile, error) {
+	fileBytes, ok := f[p.ValuesFileName]
+	if !ok {
+		fileBytes, ok = f[fmt.Sprintf("%s/%s", path.Dir(appFileName), p.ValuesFileName)]
+		if !ok {
+			return nil, nberrors.NewInvalidArgument(
+				nberrors.WithMessage("chart values file %s not found in uploads", p.ValuesFileName))
+		}
+	}
+
+	requirements := make([]*catalogv3.DeploymentRequirement, 0)
+	for _, dr := range p.DeploymentRequirements {
+		newRequirement := &catalogv3.DeploymentRequirement{
+			Name:                  dr.Name,
+			Version:               dr.Version,
+			DeploymentProfileName: dr.DeploymentProfile,
+		}
+		requirements = append(requirements, newRequirement)
+	}
+
+	parameterTemplates := make([]*catalogv3.ParameterTemplate, 0)
+	for _, pt := range p.ParameterTemplates {
+		newParameterTemplate := &catalogv3.ParameterTemplate{
+			Name:            pt.Name,
+			DisplayName:     pt.DisplayName,
+			Default:         pt.Default,
+			Type:            pt.Type,
+			Validator:       pt.Validator,
+			SuggestedValues: pt.SuggestedValues,
+			Secret:          pt.Secret,
+			Mandatory:       pt.Mandatory,
+		}
+		parameterTemplates = append(parameterTemplates, newParameterTemplate)
+	}
+
+	yamlString := string(fileBytes)
+	return &catalogv3.Profile{
+		Name:                  p.Name,
+		DisplayName:           p.DisplayName,
+		Description:           p.Description,
+		ChartValues:           yamlString,
+		DeploymentRequirement: requirements,
+		ParameterTemplates:    parameterTemplates,
+	}, nil
+}
+
+func (u *YamlReader) readDeploymentPackage(d upload.YamlSpec) error {
+	pkg := &catalogv3.DeploymentPackage{
+		Name:                    d.Name,
+		DisplayName:             d.DisplayName,
+		Description:             d.Description,
+		Version:                 d.Version,
+		Kind:                    kindFromDB(d.Kind),
+		DefaultProfileName:      d.DefaultProfile,
+		Profiles:                make([]*catalogv3.DeploymentProfile, 0, len(d.DeploymentProfiles)),
+		ApplicationReferences:   make([]*catalogv3.ApplicationReference, 0, len(d.Applications)),
+		ApplicationDependencies: make([]*catalogv3.ApplicationDependency, 0, len(d.ApplicationDependencies)),
+		Extensions:              make([]*catalogv3.APIExtension, 0, len(d.Extensions)),
+		Artifacts:               make([]*catalogv3.ArtifactReference, 0, len(d.ArtifactReferences)),
+		DefaultNamespaces:       make(map[string]string, len(d.DefaultNamespaces)),
+		Namespaces:              make([]*catalogv3.Namespace, 0, len(d.Namespaces)),
+	}
+
+	for _, a := range d.Applications {
+		pkg.ApplicationReferences = append(pkg.ApplicationReferences,
+			&catalogv3.ApplicationReference{
+				Name:    a.Name,
+				Version: a.Version,
+			})
+	}
+
+	for _, e := range d.Extensions {
+		var endpoints []*catalogv3.Endpoint
+		for _, ep := range e.Endpoints {
+			endpoints = append(endpoints,
+				&catalogv3.Endpoint{
+					ServiceName:  ep.ServiceName,
+					ExternalPath: ep.ExternalPath,
+					InternalPath: ep.InternalPath,
+					Scheme:       ep.Scheme,
+					AuthType:     ep.AuthType,
+					AppName:      ep.AppName,
+				})
+		}
+		var uiExtension *catalogv3.UIExtension
+		if e.UIExtension != nil {
+			uiExtension =
+				&catalogv3.UIExtension{
+					ServiceName: e.UIExtension.ServiceName,
+					Label:       *e.UIExtension.Label,
+					Description: e.UIExtension.Description,
+					FileName:    e.UIExtension.FileName,
+					AppName:     e.UIExtension.AppName,
+					ModuleName:  e.UIExtension.ModuleName,
+				}
+		}
+		pkg.Extensions = append(pkg.Extensions,
+			&catalogv3.APIExtension{
+				Name:        e.Name,
+				Version:     e.Version,
+				DisplayName: e.DisplayName,
+				Description: e.Description,
+				Endpoints:   endpoints,
+				UiExtension: uiExtension,
+			})
+	}
+
+	for _, a := range d.GetArtifacts() {
+		pkg.Artifacts = append(pkg.Artifacts,
+			&catalogv3.ArtifactReference{
+				Name:    a.Name,
+				Purpose: a.Purpose,
+			})
+	}
+
+	if len(d.ApplicationDependencies) > 0 {
+		for _, a := range d.ApplicationDependencies {
+			pkg.ApplicationDependencies = append(pkg.ApplicationDependencies,
+				&catalogv3.ApplicationDependency{
+					Name:     a.Name,
+					Requires: a.Requires,
+				})
+		}
+	}
+
+	if len(d.DefaultNamespaces) != 0 {
+		for k, v := range d.DefaultNamespaces {
+			pkg.DefaultNamespaces[k] = v
+		}
+	}
+
+	if len(d.Namespaces) != 0 {
+		for _, ns := range d.Namespaces {
+			pkg.Namespaces = append(pkg.Namespaces,
+				&catalogv3.Namespace{
+					Name:        ns.Name,
+					Labels:      ns.Labels,
+					Annotations: ns.Annotations,
+				})
+		}
+	}
+
+	if len(d.DeploymentProfiles) > 0 {
+		for _, profile := range d.DeploymentProfiles {
+			pkg.Profiles = append(pkg.Profiles, u.deploymentProfile(profile))
+		}
+		if pkg.DefaultProfileName == "" {
+			pkg.DefaultProfileName = d.DeploymentProfiles[0].Name
+		}
+	}
+
+	pkg.IsVisible = d.IsVisible
+	pkg.IsDeployed = d.IsDeployed
+	pkg.ForbidsMultipleDeployments = d.ForbidsMultipleDeployments
+
+	u.DeploymentPackages = append(u.DeploymentPackages, pkg)
+	return nil
+}
+
+func (u *YamlReader) deploymentProfile(deploymentProfile upload.DeploymentProfile) *catalogv3.DeploymentProfile {
+	prof := &catalogv3.DeploymentProfile{
+		Name:                deploymentProfile.Name,
+		DisplayName:         deploymentProfile.DisplayName,
+		Description:         deploymentProfile.Description,
+		ApplicationProfiles: make(map[string]string, len(deploymentProfile.ApplicationProfiles)),
+	}
+
+	for _, p := range deploymentProfile.ApplicationProfiles {
+		prof.ApplicationProfiles[p.ApplicationName] = p.ProfileName
+	}
+	return prof
+}

--- a/internal/yamlreader/yamlreader.go
+++ b/internal/yamlreader/yamlreader.go
@@ -62,6 +62,7 @@ type FileSet map[string][]byte
 
 var log dazl.Logger
 
+// KindFromDB takes a kind string and returns the enum from the protobuf
 func kindFromDB(kind string) catalogv3.Kind {
 	switch kind {
 	case kindNormal:
@@ -74,6 +75,7 @@ func kindFromDB(kind string) catalogv3.Kind {
 	return catalogv3.Kind_KIND_NORMAL
 }
 
+// ReadYamlFilesFromDir reads a directly and return a FileSet of all the YAML files
 func (u *YamlReader) ReadYamlFilesFromDir(dir string) (FileSet, error) {
 	files := make(FileSet)
 
@@ -134,6 +136,7 @@ func shouldValidateYAMLSchema(fileBytes []byte) bool {
 	return true
 }
 
+// extractTarball extracts a tarball and returns a FileSet of the files inside it.
 func (u *YamlReader) extractTarball(fileBytes []byte) (FileSet, error) {
 	contents := make(FileSet, 0)
 
@@ -176,7 +179,11 @@ func (u *YamlReader) extractTarball(fileBytes []byte) (FileSet, error) {
 	return contents, nil
 }
 
-// ExpandFileSet deals with tarballs that might be part of the original fileset.
+// ExpandFileSet takes a FileSet and returns a set of FileSets.
+// If srcFiles contains tarballs, then they are expanded into individual FileSets.
+// Thus, the return value of ExpandFileSets() is a list of FileSets
+//   - one for each taball
+//   - one for the set of raw yaml files that are not part of a tarball.
 func (u *YamlReader) ExpandFileSet(srcFiles FileSet) ([]FileSet, error) {
 	var FileSets []FileSet
 
@@ -206,6 +213,7 @@ func (u *YamlReader) ExpandFileSet(srcFiles FileSet) ([]FileSet, error) {
 	return FileSets, nil
 }
 
+// LoadYamlSpecs processes each file in a fileset and parses and validates the YAML.
 func (u *YamlReader) LoadYamlSpecs(files FileSet) (upload.YamlSpecs, error) {
 	orderedSpecs := make(upload.YamlSpecs, 0)
 
@@ -253,6 +261,7 @@ func valueOrDefault(val string, def string) string {
 	return val
 }
 
+// ReadRegistry converts an upload.YamlSpec into a Registry object.
 func (u *YamlReader) ReadRegistry(d upload.YamlSpec) (*catalogv3.Registry, error) {
 	reg := &catalogv3.Registry{
 		Name:         d.Name,
@@ -270,6 +279,7 @@ func (u *YamlReader) ReadRegistry(d upload.YamlSpec) (*catalogv3.Registry, error
 	return reg, nil
 }
 
+// ReadArtifact converts an upload.YamlSpec into an Artifact object.
 func (u *YamlReader) ReadArtifact(d upload.YamlSpec) (*catalogv3.Artifact, error) {
 	artifactBinary, err := b64.StdEncoding.DecodeString(d.Artifact)
 	if err != nil {
@@ -307,6 +317,7 @@ func (u *YamlReader) ReadArtifact(d upload.YamlSpec) (*catalogv3.Artifact, error
 	return art, nil
 }
 
+// ReadApplication converts an upload.YamlSpec into an Application object.
 func (u *YamlReader) ReadApplication(d upload.YamlSpec, f FileSet) (*catalogv3.Application, error) {
 	app := &catalogv3.Application{
 		Name:               d.Name,
@@ -349,6 +360,7 @@ func (u *YamlReader) ReadApplication(d upload.YamlSpec, f FileSet) (*catalogv3.A
 	return app, nil
 }
 
+// ReadProfile converts an upload.Profile into a Profile object.
 func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f FileSet) (*catalogv3.Profile, error) {
 	fileBytes, ok := f[p.ValuesFileName]
 	if !ok {
@@ -395,6 +407,7 @@ func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f FileSet
 	}, nil
 }
 
+// ReadDeploymentPackage converts an upload.YamlSpec into a DeploymentPackage object.
 func (u *YamlReader) ReadDeploymentPackage(d upload.YamlSpec) (*catalogv3.DeploymentPackage, error) {
 	pkg := &catalogv3.DeploymentPackage{
 		Name:                    d.Name,
@@ -507,6 +520,7 @@ func (u *YamlReader) ReadDeploymentPackage(d upload.YamlSpec) (*catalogv3.Deploy
 	return pkg, nil
 }
 
+// deploymentProfile converts an upload.DeploymentProfile into a DeploymentProfile object.
 func (u *YamlReader) deploymentProfile(deploymentProfile upload.DeploymentProfile) *catalogv3.DeploymentProfile {
 	prof := &catalogv3.DeploymentProfile{
 		Name:                deploymentProfile.Name,

--- a/internal/yamlreader/yamlreader.go
+++ b/internal/yamlreader/yamlreader.go
@@ -37,6 +37,22 @@ const (
 	helmType             = "HELM"
 )
 
+/* YamlReader is for reading YAML files
+ *
+ * For reading from a directory on disk:
+ *   reader := YamlReader{}
+ *   files, _ := reader.ReadYamlFilesFromDir("/path/to/dir")
+ *   fileSet, _ := reader.ExpandFileSet(files)
+ *   specs, _ := reader.LoadYamlSpecs(fileSet)
+ *   for _, spec := range specs {
+ *       process each spec, calling readArtifact, readApplication, etc.
+ *   }
+ *
+ * Alternatively, the initial fileset can be passed directly to ExpandFileSet()
+ * and the call to ReadFilesFromDir() can be omitted. This is used in the catalog
+ * uploader.
+ */
+
 type YamlReader struct {
 }
 

--- a/internal/yamlreader/yamlreader.go
+++ b/internal/yamlreader/yamlreader.go
@@ -11,9 +11,6 @@ import (
 	b64 "encoding/base64"
 	"errors"
 	"fmt"
-	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
-	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
-	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/validator"
 	"io"
 	"os"
 	"path"
@@ -21,6 +18,10 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	nberrors "github.com/open-edge-platform/app-orch-catalog/internal/northbound/errors"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/upload"
+	"github.com/open-edge-platform/app-orch-catalog/pkg/schema/validator"
 
 	catalogv3 "github.com/open-edge-platform/app-orch-catalog/pkg/api/catalog/v3"
 	"github.com/open-edge-platform/app-orch-catalog/pkg/malware"
@@ -37,15 +38,11 @@ const (
 )
 
 type YamlReader struct {
-	Applications       []*catalogv3.Application
-	DeploymentPackages []*catalogv3.DeploymentPackage
-	Artifacts          []*catalogv3.Artifact
-	Registries         []*catalogv3.Registry
 }
 
-// fileSet is a map of file names to their contents. It is a set of files that should be evaluated
+// FileSet is a map of file names to their contents. It is a set of files that should be evaluated
 // together. For example, it may contain applications and their profiles.
-type fileSet map[string][]byte
+type FileSet map[string][]byte
 
 var log dazl.Logger
 
@@ -61,8 +58,8 @@ func kindFromDB(kind string) catalogv3.Kind {
 	return catalogv3.Kind_KIND_NORMAL
 }
 
-func (u *YamlReader) ReadYamlFilesFromDir(dir string) (fileSet, error) {
-	files := make(fileSet)
+func (u *YamlReader) ReadYamlFilesFromDir(dir string) (FileSet, error) {
+	files := make(FileSet)
 
 	info, err := os.Stat(dir)
 	if os.IsNotExist(err) {
@@ -104,37 +101,6 @@ func (u *YamlReader) ReadYamlFilesFromDir(dir string) (fileSet, error) {
 	return files, nil
 }
 
-func (u *YamlReader) ProcessFiles(files fileSet) error {
-	// Process each fileset, load its yaml, sort, and add to the catalog.
-
-	orderedSpecs, err := u.loadYamlSpecs(files)
-	if err != nil {
-		return err
-	}
-
-	for _, d := range orderedSpecs {
-		switch d.SpecSchema {
-		case upload.DeploymentPackageType:
-			err = u.readDeploymentPackage(d)
-		case upload.DeploymentPackageLegacyType:
-			err = u.readDeploymentPackage(d)
-		case upload.ApplicationType:
-			err = u.readApplication(d, files) // application uses the fileSet to lookup profiles
-		case upload.RegistryType:
-			err = u.readRegistry(d)
-		case upload.ArtifactType:
-			err = u.readArtifact(d)
-		default:
-			return nberrors.NewInvalidArgument(nberrors.WithMessage("uploaded file %s: unhandled type %s", d.FileName, d.SpecSchema))
-		}
-		if err != nil {
-			return nberrors.NewInvalidArgument(nberrors.WithError(err), nberrors.WithMessage("uploaded file %s: %v", d.FileName, err))
-		}
-	}
-
-	return nil
-}
-
 // shouldValidateYAMLSchema determines if the schema checker should run on the given
 // artifact. If the YAML can be unmarshaled or contains the schema directive,
 // it should be validated. Values files containing {{ }} markers should
@@ -152,8 +118,8 @@ func shouldValidateYAMLSchema(fileBytes []byte) bool {
 	return true
 }
 
-func (u *YamlReader) extractTarball(fileBytes []byte) (fileSet, error) {
-	contents := make(fileSet, 0)
+func (u *YamlReader) extractTarball(fileBytes []byte) (FileSet, error) {
+	contents := make(FileSet, 0)
 
 	// Convert fileBytes into an io.Reader
 	reader := bytes.NewReader(fileBytes)
@@ -194,38 +160,37 @@ func (u *YamlReader) extractTarball(fileBytes []byte) (fileSet, error) {
 	return contents, nil
 }
 
-// loadYamlSpecs loads the contents of the specified uploads and returns them as an ordered
-// collection of YamlSpecs
-func (u *YamlReader) ExpandFileSet(srcFiles fileSet) ([]fileSet, error) {
-	var fileSets []fileSet
+// ExpandFileSet deals with tarballs that might be part of the original fileset.
+func (u *YamlReader) ExpandFileSet(srcFiles FileSet) ([]FileSet, error) {
+	var FileSets []FileSet
 
-	baseFileSet := make(fileSet, 0)
+	baseFileSet := make(FileSet, 0)
 
 	for fileName, fileContents := range srcFiles {
 		if strings.HasSuffix(fileName, ".tgz") || strings.HasSuffix(fileName, ".tar.gz") {
-			// The file is a tarvball. Extract the individual files from it and add them to a fileset
+			// The file is a tarvball. Extract the individual files from it and add them to a FileSet
 			extractedFileSet, err := u.extractTarball(fileContents)
 			if err != nil {
 				return nil, fmt.Errorf("failed to extract tarball %s: %w", fileName, err)
 			}
-			fileSets = append(fileSets, extractedFileSet)
+			FileSets = append(FileSets, extractedFileSet)
 		} else {
-			// The file is a single YAML file. Add it to the base fileset
+			// The file is a single YAML file. Add it to the base FileSet
 			baseFileSet[fileName] = fileContents
 		}
 	}
 
 	if len(baseFileSet) > 0 {
 		// If we have a base file set, add it to the list of file sets
-		fileSets = append(fileSets, baseFileSet)
+		FileSets = append(FileSets, baseFileSet)
 	}
 
 	// We will validate the yaml contents inside of loadYamlSpecs()
 
-	return fileSets, nil
+	return FileSets, nil
 }
 
-func (u *YamlReader) loadYamlSpecs(files fileSet) (upload.YamlSpecs, error) {
+func (u *YamlReader) LoadYamlSpecs(files FileSet) (upload.YamlSpecs, error) {
 	orderedSpecs := make(upload.YamlSpecs, 0)
 
 	for fileName, fileBytes := range files {
@@ -272,7 +237,7 @@ func valueOrDefault(val string, def string) string {
 	return val
 }
 
-func (u *YamlReader) readRegistry(d upload.YamlSpec) error {
+func (u *YamlReader) ReadRegistry(d upload.YamlSpec) (*catalogv3.Registry, error) {
 	reg := &catalogv3.Registry{
 		Name:         d.Name,
 		DisplayName:  d.DisplayName,
@@ -286,14 +251,13 @@ func (u *YamlReader) readRegistry(d upload.YamlSpec) error {
 		Cacerts:      d.CACerts,
 	}
 
-	u.Registries = append(u.Registries, reg)
-	return nil
+	return reg, nil
 }
 
-func (u *YamlReader) readArtifact(d upload.YamlSpec) error {
+func (u *YamlReader) ReadArtifact(d upload.YamlSpec) (*catalogv3.Artifact, error) {
 	artifactBinary, err := b64.StdEncoding.DecodeString(d.Artifact)
 	if err != nil {
-		return nberrors.NewInvalidArgument(
+		return nil, nberrors.NewInvalidArgument(
 			nberrors.WithResourceType(nberrors.ArtifactType),
 			nberrors.WithMessage("error decoding base64 from file %s %v", d.FileName, err))
 	}
@@ -305,12 +269,12 @@ func (u *YamlReader) readArtifact(d upload.YamlSpec) error {
 				log.Warn("Malware scanner is not available. Skipping scan due to permissive mode.")
 			} else {
 				log.Warn("Malware scanner returned error %s", err)
-				return nberrors.NewUnavailable(
+				return nil, nberrors.NewUnavailable(
 					nberrors.WithResourceType(nberrors.ArtifactType),
 					nberrors.WithMessage("malware scanner configured but not available"))
 			}
 		} else if !okay {
-			return nberrors.NewInvalidArgument(
+			return nil, nberrors.NewInvalidArgument(
 				nberrors.WithResourceType(nberrors.ArtifactType),
 				nberrors.WithMessage("malware detected: %s", res))
 		}
@@ -324,11 +288,10 @@ func (u *YamlReader) readArtifact(d upload.YamlSpec) error {
 		Artifact:    artifactBinary,
 	}
 
-	u.Artifacts = append(u.Artifacts, art)
-	return nil
+	return art, nil
 }
 
-func (u *YamlReader) readApplication(d upload.YamlSpec, f fileSet) error {
+func (u *YamlReader) ReadApplication(d upload.YamlSpec, f FileSet) (*catalogv3.Application, error) {
 	app := &catalogv3.Application{
 		Name:               d.Name,
 		Version:            d.Version,
@@ -348,7 +311,7 @@ func (u *YamlReader) readApplication(d upload.YamlSpec, f fileSet) error {
 		for _, p := range d.Profiles {
 			prof, err := u.readProfile(d.FileName, p, f)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			app.Profiles = append(app.Profiles, prof)
 		}
@@ -367,11 +330,10 @@ func (u *YamlReader) readApplication(d upload.YamlSpec, f fileSet) error {
 		}
 	}
 
-	u.Applications = append(u.Applications, app)
-	return nil
+	return app, nil
 }
 
-func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f fileSet) (*catalogv3.Profile, error) {
+func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f FileSet) (*catalogv3.Profile, error) {
 	fileBytes, ok := f[p.ValuesFileName]
 	if !ok {
 		fileBytes, ok = f[fmt.Sprintf("%s/%s", path.Dir(appFileName), p.ValuesFileName)]
@@ -417,7 +379,7 @@ func (u *YamlReader) readProfile(appFileName string, p upload.Profile, f fileSet
 	}, nil
 }
 
-func (u *YamlReader) readDeploymentPackage(d upload.YamlSpec) error {
+func (u *YamlReader) ReadDeploymentPackage(d upload.YamlSpec) (*catalogv3.DeploymentPackage, error) {
 	pkg := &catalogv3.DeploymentPackage{
 		Name:                    d.Name,
 		DisplayName:             d.DisplayName,
@@ -526,8 +488,7 @@ func (u *YamlReader) readDeploymentPackage(d upload.YamlSpec) error {
 	pkg.IsDeployed = d.IsDeployed
 	pkg.ForbidsMultipleDeployments = d.ForbidsMultipleDeployments
 
-	u.DeploymentPackages = append(u.DeploymentPackages, pkg)
-	return nil
+	return pkg, nil
 }
 
 func (u *YamlReader) deploymentProfile(deploymentProfile upload.DeploymentProfile) *catalogv3.DeploymentProfile {


### PR DESCRIPTION
## Description

This patch implements a tool that converts a deployment package into a set of "helm install" commands that may be used to install the package without an Orchestrator.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
