### PR TITLE
add newer cirros VM for upgrade test

### DIFF
--- a/app-orch-tutorials/cirros-vm-0.1.1/README.md
+++ b/app-orch-tutorials/cirros-vm-0.1.1/README.md
@@ -1,0 +1,30 @@
+<!---
+  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Upgraded Deployment Package for Cirros VM
+
+This Deployment Package is intended to use for testing upgrades.
+
+It is identical to the one in ../cirros-vm with the sole difference that is uses version 1.0.0 of the cirros vm image rather than 0.36.4
+
+For documentation, see the README in ../cirros-vm
+
+# Testing upgrades
+
+To test an upgrade, follow these steps:
+
+1. Import version 0.1.0 of the Cirros VM to the orchestrator
+
+2. Deploy version 0.1.0 of the Cirros VM
+
+3. Use VNC to inspect that the Cirros VM is alive and health. `uname -a` should show kernel 4.4.0
+
+4. Import version 0.1.1 of the Cirros VM to the orchestrator
+
+5. Orchestrator should show "upgrades available" on the VM deployed in step 2.
+
+6. Upgrade the VM from 0.1.0 to 0.1.1 using the orchestrator. The VM will be unavailable for a short while while it restarts. This may take a few minutes.
+
+7. Use VNC to inspect that the Cirros VM is alive and health. `uname -a` should show kernel 5.3.0, confirming the VM has been upgraded.

--- a/app-orch-tutorials/cirros-vm-0.1.1/app.yaml
+++ b/app-orch-tutorials/cirros-vm-0.1.1/app.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+specSchema: "Application"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: "cirros-container-disk"
+version: 0.1.1
+description: "A demo VM using Cirros container disk"
+
+
+helmRegistry: "kubevirt-community-stack"
+chartName: "kubevirt-vm"
+chartVersion: "0.4.15"
+
+profiles:
+  - name: "default"
+    valuesFileName: "values.yaml"

--- a/app-orch-tutorials/cirros-vm-0.1.1/dp.yaml
+++ b/app-orch-tutorials/cirros-vm-0.1.1/dp.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+specSchema: "DeploymentPackage"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: "cirros-container-disk"
+displayName: "Cirros Container Disk Demo VM"
+description: "A demo VM using Cirros container disk"
+version: "0.1.1"
+
+
+applications:
+  - name: "cirros-container-disk"
+    version: 0.1.1
+
+defaultNamespaces:
+  "cirros-container-disk": "cirros-vm"
+
+deploymentProfiles:
+  - name: "default"
+    applicationProfiles:
+      - application: "cirros-container-disk"
+        profile: "default"

--- a/app-orch-tutorials/cirros-vm-0.1.1/registry.yaml
+++ b/app-orch-tutorials/cirros-vm-0.1.1/registry.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+specSchema: "Registry"
+schemaVersion: "0.1"
+$schema: "https://schema.intel.com/catalog.orchestrator/0.1/schema"
+
+name: "kubevirt-community-stack"
+description: "kubevirt-community-stack helm registry"
+type: "HELM"
+
+rootUrl: "https://cloudymax.github.io/kubevirt-community-stack"

--- a/app-orch-tutorials/cirros-vm-0.1.1/values.yaml
+++ b/app-orch-tutorials/cirros-vm-0.1.1/values.yaml
@@ -1,0 +1,571 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+virtualMachine:
+  # -- name of the virtualMachine or virtualMachinePool object
+  name: cirros-vm
+
+  namespace: cirros-vm
+  # -- Create the VM as a KubevirtMachineTemplate for use with Cluster API
+  # Does not support VM Pools
+  capiMachineTemplate: false
+
+  # -- One of 'Always' `RerunOnFailure` `Manual` `Halted` `Once`
+  # See: https://kubevirt.io/user-guide/compute/run_strategies/#runstrategy
+  runStrategy: "Always"
+
+  features:
+    # -- Enable KVM acceleration.
+    # Setting the 'hidden' flag to `true` will obscure kvm from the host.
+    # Set `hidden` to `false` when using vGPU in Windows Guests.
+    kvm:
+      enabled: true
+      hidden: false
+
+      # -- Set default hyperv settings for windows guests
+    hyperv: false
+
+    # Enable ACPI platform event device
+    acpiEnabled: true
+
+    # -- Make pod network interface the default for the VM
+    autoattachPodInterface: true
+
+    # -- Attach a serial console device
+    autoattachSerialConsole: true
+
+    # -- Attach a basic graphics device for VNC access
+    autoattachGraphicsDevice: true
+
+    # -- Enhances network performance by allowing multiple TX and RX queues.
+    networkInterfaceMultiqueue: true
+
+  # -- Options for machine clock
+  clock:
+    enabled: true
+
+    # -- Set clock timezone eg: "Europe/Amsterdam" or "utc"
+    timezone: utc
+
+    # -- High Precision Event Timer
+    hpet:
+      enabled: true
+      present: false
+
+    # -- Programmable interval timer
+    pit:
+      enabled: true
+      tickPolicy: delay
+
+    # -- Real-Time Clock
+    rtc:
+      enabled: true
+      tickPolicy: catchup
+
+    # -- Paravirtualized clock that provides better accuracy and performance.
+    # Recommended clock source for KVM guest virtual machines.
+    kvm: true
+
+    # -- Hyper-V's reference time counter for use with Windows guests.
+    hyperv: false
+
+  firmware:
+    # Enable System Management Mode (required for secureboot)
+    smmEnabled: false
+
+    # -- Enable EFI bios and secureboot
+    efi:
+      enabled: true
+      secureBoot: false
+    uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
+
+
+  machine:
+    # -- If a Pod cannot be scheduled, lower priorityClass Pods will be evicted
+    priorityClassName: kubevirt-cluster-critical
+
+    # -- Define CPU, RAM, GPU, HostDevice settings for VMs.
+    # Overrides: vCores, memory, gpus
+    instancetype:
+      enabled: false
+      name: standard-small
+      kind: virtualMachineClusterInstancetype
+
+    # -- System Arch. Supported options are amd64 and arm64
+    architecture: amd64
+
+    # -- QEMU virtual-machine type. Options are q35 and i440fx
+    machineType: q35
+
+    # -- Specify hots-passthrough or a named cpu model
+    # https://www.qemu.org/docs/master/system/qemu-cpu-models.html
+    cpuModel: host-model
+
+    # -- Number of simulated CPU sockets.
+    # Note: Multiple cpu-bound microbenchmarks show a significant
+    # performance advantage when using sockets instead of cores
+    # Does not work with some cpuManagerPolicy options.
+    sockets: 1
+
+    # -- Number of Virtual cores to pass to the Guest
+    # ignored when instancetype is defined
+    vCores: 2
+
+    # -- Enable simulation of Hyperthre ading on Intel CPUs or SMT AMD CPUs.
+    threads: 1
+
+    # -- Pin QEMU process threads to specific physical cores
+    # Requires `--cpu-manager-policy` enabled in kubelet
+    pinCores: true
+
+    # -- In order to enhance the real-time support in KubeVirt and provide
+    # improved latency, KubeVirt will allocate an additional dedicated CPU,
+    # exclusively for the emulator thread, to which it will be pinned.
+    # Requires `dedicatedCpuPlacement` set to `true`
+    emulatorThread: false
+
+    # -- Amount of RAM to pass to the Guest. Ignored when instancetype is defined
+    memory:
+      base: 2Gi
+      overcommit:
+        # -- Enable memory overcommitment. Tells VM it has more RAM than requested.
+        # VMI becomes Burtable QOS class and may be preempted when node is under memory pressure.
+        # GPU passthrough and vGPU will not function with overcommit enabled.
+        enabled: false
+        limit: 4Gi
+
+        # -- Do not allocate hypervisor overhead memory to VM. Will work for as
+        # long as most of the VirtualMachineInstances do not request the full memory.
+        overhead: false
+
+  # -- GPUs to pass to guest, requires that the GPUs are pre-configured in the
+  # kubevirt custom resource. ignored when instancetype is defined.
+  # ramFB & display may only be enabled on 1 vGPU
+  gpus: []
+  # - name: gpu0
+  #   deviceName: nvidia.com/GRID_RTX6000-4Q
+  #   virtualGPUOptions:
+  #     display:
+  #       enabled: true
+  #       ramFB:
+  #         enabled: true
+
+
+  # -- virtual network interface config options.
+  # See: https://kubevirt.io/user-guide/network/interfaces_and_networks/#interfaces
+  interfaces:
+    # -- bridge mode, vms are connected to the network via a linux "bridge".
+    # Pod network IP is delegated to vm via DHCPv4. VM must use DHCP for an IP
+    - masquerade: {}
+      name: default
+      model: virtio
+
+  networks:
+    # Use the default pod network
+    - name: default
+      pod: {}
+
+#########################
+# Create a Virtual Machine Pool
+# Vm pools should be used with ephemeral disks or containerdisks
+# otherwise they would all fight over the same PVC.
+virtualMachinePool:
+  enabled: false
+
+  # -- number of replicas to create. Ignored when hpa is set to 'true'
+  replicas: 2
+  hpa:
+    enabled: true
+    maxReplicas: 5
+    minReplicas: 1
+
+# -- controls hypervisor behavior when I/O errors occur on disk read or write.
+# Possible values are: 'report', 'ignore', 'enospace'
+diskErrorPolicy: "report"
+
+# -- List of disks to create for the VM, Will be used to create Datavolumes or PVCs.
+disks:
+  #################################################
+  # DataVolume disk with URL source example
+  #################################################
+  # - name: harddrive
+  # -- Disk type: disk, cdrom, filesystem, or lun
+  #  type: disk
+  # -- Bus type: sata or virtio
+  # bus: virtio
+  # -- Sets disk position in boot order, lower numbers are checked earlier
+  # bootorder: 2
+  # -- Set disk to be Read-only
+  # readonly: false
+  # -- Size of disk in GB
+  # pvsize: 16Gi
+  # -- Storage class to use for the pvc
+  # pvstorageClassName: fast-raid
+  # -- Access mode for the PVC
+  # pvaccessMode: ReadWriteOnce
+  # -- source type of the disk image. One of `url`, `pvc`
+  # source: url
+  # -- URL of cloud-image
+  # url: "https://buildstars.online/debian-12-generic-amd64-daily.qcow2"
+
+  #########################################################
+  # Ephemeral disk example
+  # no persistance, these are deleted after the VM exits
+  # requires an existing PVC as a backing file.
+  # Performance degrades at liarge sizes (100G+)
+  #########################################################
+  #  - name: harddrive
+  #    type: disk
+  #    bus: virtio
+  #    bootorder: 2
+  #    readonly: false
+  #    pvc: debian12
+  #    ephemeral: true
+
+  ########################################################
+  # DataVolume disk with existing PVC source example
+  ########################################################
+  # - name: harddrive
+  #   type: disk
+  #   bus: virtio
+  #   bootorder: 2
+  #   readonly: false
+  #   pvsize: 64G
+  #   pvstorageClassName: local-path
+  #   nodePlacement: scremlin
+  #   pvaccessMode: ReadWriteOnce
+  #   source: pvc
+  #   pvcnamespace: kubevirt
+  #   pvcname: debian12
+
+  ##########################################################
+  # ISO live-image example
+  ##########################################################
+  # - name: iso
+  #   type: cdrom
+  #   bus: sata
+  #   bootorder: 1
+  #   readonly: true
+  #   pvsize: 8G
+  #   pvstorageClassName: local-path
+  #   nodePlacement: node0
+  #   pvaccessMode: ReadWriteOnce
+  #   source: "https://www.itechtics.com/?dl_id=173"
+
+  ##########################################################
+  # Empty PVC as disk example
+  ##########################################################
+  # - name: harddrive
+  #   type: disk
+  #   bus: virtio
+  #   bootorder: 2
+  #   readonly: false
+  #   pvsize: 32G
+  #   pvstorageClassName: local-path
+  #   nodePlacement: node0
+  #   pvaccessMode: ReadWriteOnce
+
+  ##########################################################
+  # Container Disk Example
+  ##########################################################
+  - name: cirros-disk
+    type: disk
+    bus: virtio
+    bootorder: 3
+    readonly: false
+    image: "quay.io/kubevirt/cirros-container-disk-demo:v1.0.0"
+
+###########################################################
+# Local Disk example
+# Not working, will have to open a ticket
+# disks need to be owned by 107:messagebus
+# disks cannot be mounted, file systems unidentifiable
+###########################################################
+# - name: localfile
+#   type: hostDisk
+#   # -- Enter a capacity amount to create a new disk
+#   # otherwise expects an existing disk
+#   capacity: 500G
+#   path: /mnt/raid1/hdd2.img
+
+###########################################################
+# ConfigMap example
+# Attach a configmap to VM as an ISO disk or FileSystem
+# Must be mounted via cloud init
+# see https://kubevirt.io/user-guide/storage/disks_and_volumes/#as-a-disk and
+# https://kubevirt.io/user-guide/storage/disks_and_volumes/#as-a-filesystem
+#
+# Configmaps may also specify the volumeLable field which informs the guest OS
+# of the disk name. Useful for windows vms.
+###########################################################
+#  - name: my-configmap
+#    type: configmap
+#    volumeLabel: cfgdata
+#    method: disk
+#    bootorder: 3
+#    readonly: true
+#    configMap: my-configmap
+#    serialNumber: CVLY623300HK240D
+
+###########################################################
+# ConfigMap example
+# Attach a configmap to VM as an ISO disk or FileSystem
+# Must be mounted via cloud init
+# see https://kubevirt.io/user-guide/storage/disks_and_volumes/#as-a-disk and
+# https://kubevirt.io/user-guide/storage/disks_and_volumes/#as-a-filesystem
+###########################################################
+#  - name: my-secret
+#    type: secret
+#    method: disk
+#    bootorder: 3
+#    readonly: true
+#    secretName: test
+#    serialNumber: CVLY623300HK240D
+
+# -- Use an existing cloud-init userdata secret
+# ignored if cloudinit subchart is enabled.
+userDataSecret:
+  enabled: false
+  name: ""
+
+# -- Enable or disable usage of cloud-init sub-chart
+cloudinit:
+  enabled: true
+
+  # Not all cloud-init modules are currently supported
+  # https://cloudinit.readthedocs.io/en/latest/reference/modules.html
+
+  # -- name of secret in which to save the user-data file
+  secret_name: test-scrapmetal-user-data
+
+  # -- image version
+  image: deserializeme/kv-cloud-init:v0.0.1
+
+  # -- Choose weather to create a service-account or not. Once a SA has been created
+  # you should set this to false on subsequent runs.
+  serviceAccount:
+    create: true
+    name: cloud-init-sa
+    # Ignored is `create` set to true
+    existingServiceAccountName: "cloud-init-sa"
+
+  # -- Set up mount points. mounts contains a list of lists.
+  # The inner list contains entries for an /etc/fstab line
+  mounts: []
+
+  # -- creates a swap file using human-readable values.
+  swap:
+    enabled: false
+    filename: /swapfile
+    size: 1G
+    maxsize: 1G
+
+  disk_setup: {}
+  #  -- The name of the device.
+  #  - name: /dev/vdb
+  #    # -- This is a list of values, with the percentage of disk that
+  #    # the partition will take. When layout is “true”, it instructs cloud-init
+  #    # to single-partition the entire device. When layout is “false” it means
+  #    # “don’t partition” or “ignore existing partitioning”.
+  #    layout: true
+  # -- “false” is the default which means that the device will be checked for
+  #    # a partition table and/or filesystem. “true” is cowboy mode, no checks.
+  #    overwrite: false
+  #    # -- Supported options ate `gpt` and `mbr`
+  #    table_type: 'gpt'
+
+  fs_setup: []
+  # -- The device name.
+  #  - device: /dev/vdb
+  #    # -- The filesystem type. Supports ext{2,3,4} and vfat
+  #    filesystem: ext4
+  #    # -- The filesystem label to be used. If set to “None”, no label is used.
+  #    label: None
+  #    # -- Options are `auto|any`, `auto`, or `any`
+  #    partition: 'auto|any'
+
+  # -- Dont recreate script configmap. Set to true when keeping multiple
+  # cloud-init secrets in the same namespace
+  existingConfigMap: false
+
+  # -- Run envsubst against bootcmd and runcmd fields at the beginning of templating
+  # Not an official part of cloid-init
+  envsubst: false
+
+  extraEnvVars: []
+  #  - name: VNC_PASS
+  #    valueFrom:
+  #      secretKeyRef:
+  #        name: test-password
+  #        key: "password"
+
+  # -- virtual-machine hostname
+  hostname: test
+
+  # -- namespace in which to create resources
+  namespace: cirros-vm
+
+  # -- Disable root login over ssh
+  disable_root: false
+
+  # -- when enabled job sleeps to allow user to exec into the container
+  debug: false
+
+  # -- salt used for password generation
+  salt: "saltsaltlettuce"
+
+  # -- networking options
+  network:
+    # --  disable cloud-init’s network configuration capability and rely on
+    # other methods such as embedded configuration or other customisations.
+    config: disabled
+
+  # -- add wireguard configuration from existing secret or as plain-text
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#wireguard
+  wireguard: []
+  #  interfaces:
+  #    - name: wg0
+  #      config_path: /etc/wireguard/wg0.conf
+  #      existingSecret:
+  #        name: wg0-credentials
+  #        key: wg0.conf
+
+  # -- user configuration options
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups
+  # do NOT use 'admin' as username - it conflicts with multiele cloud-images
+  users:
+    - name: test
+      groups: users, admin, docker, sudo, kvm
+      sudo: ALL=(ALL) NOPASSWD:ALL
+      shell: /bin/bash
+      lock_passwd: false
+
+      # -- set user password from existing secret or generate random
+      password:
+        random: true
+      #  random: false
+      #  existingSecret:
+      #    name: admin-password
+      #    key: password
+
+      # -- import user ssh public keys from github, gitlab, or launchpad
+      # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ssh
+      ssh_import_id: []
+
+      # -- provider user ssh pub key as plaintext
+      ssh_authorized_keys: []
+
+  # -- Add CA certificates
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ca-certificates
+  ca_certs: []
+  #  remove_defaults: true
+  #  trusted:
+  #    - certificate
+
+  # -- Run arbitrary commands early in the boot process
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#bootcmd
+  boot_cmd: []
+
+  # -- Write arbitrary files to disk.
+  # Files my be provided as plain-text or downloaded from a url
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#write-files
+  write_files: []
+
+  # -- Update, upgrade, and install packages
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#package-update-upgrade-install
+  package_reboot_if_required: false
+  package_update: true
+  package_upgrade: false
+  packages: []
+  #  - docker.io
+
+  # -- Run arbitrary commands
+  # See https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd
+  runcmd: []
+  #  - docker run -d -p 8080:80 nginx
+
+# -- Service cinfiguration. Used to expose VM to the outside world.
+# Accepts a list of ports to open.
+service:
+  - name: test-service
+    type: NodePort
+    externalTrafficPolicy: Cluster
+    ports:
+      - name: nginx
+        port: 8080
+        targetPort: 8080
+        protocol: TCP
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: "nginx"
+  hostname: "novnc.buildstar.online"
+  annotations: {}
+  #  cert-manager.io/cluster-issuer: "letsencrypt-staging"
+  tls: []
+  #  enabled: true
+  #  secretName: "tls-kubevirt-manager"
+  # paths:
+  # - path: /
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: test-service
+  #       port:
+  #         number: 8080
+
+networkPolicy:
+  # -- Enable the creation of network policies
+  enabled: false
+  egress:
+    # Allow communication to Kubernetes DNS service
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+
+    # Allow internet access
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            # Exclude traffic to Kubernetes service IPs and pods
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+
+  ingress:
+    # Allow internet access from the ingress controller
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: "ingress-nginx"
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: "ingress-nginx"
+
+# -- set tieming and port number for liveness probe
+#  livenessProbe:
+#  initialDelaySeconds: 60
+#  periodSeconds: 10
+#  tcpSocket:
+#    port: 8080
+#  timeoutSeconds: 10
+
+# -- set tieming and port number for readiness probe
+# readinessProbe:
+#   initialDelaySeconds: 60
+#   periodSeconds: 10
+#   timeoutSeconds: 10
+#   failureThreshold: 6
+#   successThreshold: 1
+#   httpGet:
+#     port: 8080


### PR DESCRIPTION
## Description

Adds a newer version of the Cirros VM that can be used for upgrade testing. A README.md file has been added with some notes on upgrade testing.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
