### PR TITLE
update orch-ci to 0.1.39 to fix semgrep issues

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -34,6 +34,6 @@ jobs:
           persist-credentials: false
 
       - name: Update pull requests
-        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@070a95caeeed643fc9d1a34c11eac78179ce136d  # 0.1.34
+        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@bf0ca523f17ab9f79ad5f45df760d302b68ac932 # 0.1.39
         with:
           github_token: ${{ secrets.SYS_ORCH_GITHUB }}

--- a/.github/workflows/go-fuzz.yaml
+++ b/.github/workflows/go-fuzz.yaml
@@ -28,7 +28,7 @@ jobs:
   go-fuzz-catalog:
     if: ${{ inputs.run_catalog || github.event_name == 'schedule' }}
     name: Catalog Go Fuzzing Tests
-    uses: open-edge-platform/orch-ci/.github/workflows/apporch-go-fuzz.yml@070a95caeeed643fc9d1a34c11eac78179ce136d # v0.1.34
+    uses: open-edge-platform/orch-ci/.github/workflows/apporch-go-fuzz.yml@bf0ca523f17ab9f79ad5f45df760d302b68ac932 # 0.1.39
     with:
       # Declare 4800 secs duration since schedule event will not pick up input values from workflow_dispatch
       fuzz_seconds: ${{ fromJSON(inputs.fuzz_seconds_catalog || 4800) }}

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@070a95caeeed643fc9d1a34c11eac78179ce136d  # v0.1.34
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@bf0ca523f17ab9f79ad5f45df760d302b68ac932 # 0.1.39
     with:
       run_version_check: true
       run_dep_version_check: true

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           persist-credentials: false
       - name: "Verify Branch Name"
-        uses: open-edge-platform/orch-ci/verify-branch-name@070a95caeeed643fc9d1a34c11eac78179ce136d # v0.1.34
+        uses: open-edge-platform/orch-ci/verify-branch-name@bf0ca523f17ab9f79ad5f45df760d302b68ac932 # 0.1.39
   pre-merge-pipeline:
     needs: pre-checks
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@070a95caeeed643fc9d1a34c11eac78179ce136d # v0.1.34
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@bf0ca523f17ab9f79ad5f45df760d302b68ac932 # 0.1.39
     with:
       bootstrap_tools: "go,gotools,golang-lint,nodejs,buf,hadolint,opa"
       run_version_check: true


### PR DESCRIPTION
## Description

update orch-ci to 0.1.39 to fix semgrep issues in github actions.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
