### PR TITLE
Updating the Geti bitnami shell image

### DIFF
--- a/app-orch-tutorials/geti/deployment-package/geti-control-plane-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-control-plane-values.yaml
@@ -4,6 +4,8 @@
 global:
   registry_address: ghcr.io
   docker_namespace: open-edge-platform/geti
+  debian:
+    name: os-shell:12-debian-12-r47
 
 auth-proxy:
   certificate:

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-cpu-intel-proxy-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-cpu-intel-proxy-values.yaml
@@ -15,6 +15,8 @@ global:
   http_proxy: http://proxy-dmz.intel.com:912
   https_proxy: http://proxy-dmz.intel.com:912
   no_proxy: "127.0.0.1,localhost,.impt,.svc,.cluster.local"
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -74,3 +76,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-cpu-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-cpu-values.yaml
@@ -11,6 +11,8 @@ global:
   registry_address: ghcr.io
   workflow_versions: 2.10.1
   manage_users_roles: true
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -70,3 +72,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-intel-i915-intel-proxy-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-intel-i915-intel-proxy-values.yaml
@@ -15,6 +15,8 @@ global:
   http_proxy: http://proxy-dmz.intel.com:912
   https_proxy: http://proxy-dmz.intel.com:912
   no_proxy: "127.0.0.1,localhost,.impt,.svc,.cluster.local"
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -74,3 +76,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-intel-i915-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-intel-i915-values.yaml
@@ -11,6 +11,8 @@ global:
   registry_address: ghcr.io
   workflow_versions: 2.10.1
   manage_users_roles: true
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -70,3 +72,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-intel-xe-intel-proxy-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-intel-xe-intel-proxy-values.yaml
@@ -15,6 +15,8 @@ global:
   http_proxy: http://proxy-dmz.intel.com:912
   https_proxy: http://proxy-dmz.intel.com:912
   no_proxy: "127.0.0.1,localhost,.impt,.svc,.cluster.local"
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -74,3 +76,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-intel-xe-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-intel-xe-values.yaml
@@ -11,6 +11,8 @@ global:
   registry_address: ghcr.io
   workflow_versions: 2.10.1
   manage_users_roles: true
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -70,3 +72,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-nvidia-intel-proxy-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-nvidia-intel-proxy-values.yaml
@@ -15,6 +15,8 @@ global:
   http_proxy: http://proxy-dmz.intel.com:912
   https_proxy: http://proxy-dmz.intel.com:912
   no_proxy: "127.0.0.1,localhost,.impt,.svc,.cluster.local"
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -74,3 +76,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47

--- a/app-orch-tutorials/geti/deployment-package/geti-impt-nvidia-values.yaml
+++ b/app-orch-tutorials/geti/deployment-package/geti-impt-nvidia-values.yaml
@@ -11,6 +11,8 @@ global:
   registry_address: ghcr.io
   workflow_versions: 2.10.1
   manage_users_roles: true
+  debian:
+    name: os-shell:12-debian-12-r47
 
 spice-db:
   fullnameOverride: impt-spice-db
@@ -70,3 +72,8 @@ modelmesh-serving:
   certificate:
     issuerRef:
       name: edge-node-cluster-issuer
+
+etcd:
+  volumePermissions:
+    image:
+      name: os-shell:12-debian-12-r47


### PR DESCRIPTION
## Description

Replaces the reference to the obsolete image `docker.io/bitnami/bitnami-shell:11-debian-11-r136`
with `docker.io/bitnami/os-shell:12-debian-12-r47` for Gei helm charts for Geti 2.10.1 (for Geti 2.11.0 this values is already present)
 
## Changes

Updated values files in Geti deployment packages.

## Additional Information

Try installing Geti

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
