### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The workflow will now also trigger on any tag push, in addition to the existing branch triggers.

* [`.github/workflows/post-merge.yaml`](diffhunk://#diff-718495b98036156c667b0e7e9a1bb1535a04a0e87ef400a3274eceb9baff864dR12-R13): Added support for triggering the workflow on any pushed tag by adding a `tags` key with a wildcard pattern.
